### PR TITLE
Dependency cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
     "protocolify": "^4.0.0",
     "read-pkg-up": "^9.1.0",
     "reflect-metadata": "^0.1.13",
-    "schema-dts": "^1.1.0",
     "terminal-link": "^3.0.0",
     "type-fest": "^3.1.0",
     "typefs": "^1.1.147",

--- a/package.json
+++ b/package.json
@@ -77,9 +77,10 @@
     "dot-prop": "^7.2.0",
     "dotenv": "^16.0.3",
     "filenamify": "^5.1.1",
+    "htmlmetaparser": "^2.1.2",
+    "htmlparser2": "^8.0.1",
     "humanize-url": "^3.0.0",
     "inquirer": "^9.1.4",
-    "jsonld": "^8.1.0",
     "lodash": "^4.17.21",
     "log-symbols": "^5.1.0",
     "luxon": "^3.1.0",
@@ -104,7 +105,6 @@
     "@types/content-type": "^1.1.5",
     "@types/html-to-text": "^8.1.1",
     "@types/inquirer": "^9.0.3",
-    "@types/jsdom": "^20.0.0",
     "@types/lodash": "^4.14.189",
     "@types/luxon": "^3.1.0",
     "@types/mime": "^3.0.1",
@@ -112,7 +112,6 @@
     "@types/node": "^18.11.0",
     "@types/object-hash": "^2.2.1",
     "@types/uuid": "^8.3.4",
-    "@types/jsonld": "^1.5.8",
     "oclif": "^3",
     "shx": "^0.3.3",
     "ts-node": "^10.8.0",
@@ -126,11 +125,9 @@
     "crawlee": "^3.1.0",
     "googleapis": "^108.0.1",
     "html-to-text": "^8.2.1",
-    "jsdom": "^20.0.1",
     "listr2": "^5.0.5",
     "playwright": "^1.27.1",
     "readability-scores": "^1.0.8",
-    "xlsx": "https://cdn.sheetjs.com/xlsx-0.18.12/xlsx-0.18.12.tgz",
-    "xpath-ts": "^1.3.13"
+    "xlsx": "https://cdn.sheetjs.com/xlsx-0.18.12/xlsx-0.18.12.tgz"
   }
 }

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "@autogram/url-tools": "^2.5.2",
     "@oclif/plugin-help": "^5",
     "@oclif/plugin-plugins": "^2.1.6",
+    "@salesforce/ts-types": "^1.7.1",
     "@sindresorhus/is": "^5.3.0",
     "@sindresorhus/slugify": "^2.1.1",
     "@vladfrangu/async_event_emitter": "^2.1.2",
@@ -93,7 +94,6 @@
     "read-pkg-up": "^9.1.0",
     "reflect-metadata": "^0.1.13",
     "terminal-link": "^3.0.0",
-    "type-fest": "^3.1.0",
     "typefs": "^1.1.147",
     "uuid": "^9.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spidergram",
-  "version": "0.6.0",
+  "version": "0.7.0-dev",
   "description": "Structural analysis tools for complex web sites",
   "main": "./dist/index.js",
   "exports": "./dist/index.js",

--- a/spidegram.example.json
+++ b/spidegram.example.json
@@ -1,5 +1,6 @@
 {
   "name": "spidergram",
+  "description": "Example configuration for a Spidergram crawling project; Copy this file to spidergram.json to use its settings.",
   "root": "./",
   "files": {
     "default": "downloads",

--- a/src/cli/commands/analyze.ts
+++ b/src/cli/commands/analyze.ts
@@ -45,7 +45,11 @@ export default class Analyze extends SgCommand {
       task: async (resource) => {
         if (is.nonEmptyStringAndNotWhitespace(resource.body)) {
           if (flags.metadata) {
-            resource.data = await HtmlTools.getMetadata(resource);
+            const data: Record<string, unknown> = {
+              ...await HtmlTools.getMetadata(resource),
+              bodyAttributes: HtmlTools.getBodyAttributes(resource.body)
+            };
+            resource.data = data;
           }
 
           let text = '';
@@ -55,11 +59,13 @@ export default class Analyze extends SgCommand {
             });
           }
 
-          if (flags.text) { 
-            resource.text = text;
-          }
-          if (flags.readability) {
-            resource.readability = TextTools.calculateReadability(text);
+          if (text.length > 0) {
+            if (flags.text) { 
+              resource.text = text;
+            }
+            if (flags.readability) {
+              resource.readability = TextTools.calculateReadability(text);
+            }
           }
 
           await graph.push(resource);

--- a/src/cli/commands/analyze.ts
+++ b/src/cli/commands/analyze.ts
@@ -45,7 +45,7 @@ export default class Analyze extends SgCommand {
       task: async (resource) => {
         if (is.nonEmptyStringAndNotWhitespace(resource.body)) {
           if (flags.metadata) {
-            resource.meta = HtmlTools.getMetaTags(resource.body);
+            resource.data = await HtmlTools.getMetadata(resource);
           }
 
           let text = '';

--- a/src/cli/sg-command.ts
+++ b/src/cli/sg-command.ts
@@ -45,6 +45,17 @@ export abstract class SgCommand extends Command {
     verbose: CLI.outputFlags.verbose
   }
 
+
+  /**
+   * Given a {JobStatus} object, display a status update to the user.
+   * 
+   * By default, it will advance the console progress bar and update the ETA.
+   * If the command is running in verbose mode, a line will be logged to stderr.
+   * If the command is running in silent mode, nothing will be displayed.
+   *
+   * @protected
+   * @param {JobStatus} status
+   */
   protected updateProgress(status: JobStatus) {
     switch (this.output) {
       case OutputLevel.verbose: {
@@ -76,6 +87,15 @@ export abstract class SgCommand extends Command {
     }
   }
 
+
+  /**
+   * Given a {JobStatus} object, print a summary of what work was perfomed,
+   * how long the operation took, and whether any errors were encountered.
+   *
+   * @protected
+   * @param {JobStatus} status
+   * @param {boolean} [listFailures=true]
+   */
   protected summarizeStatus(status: JobStatus, listFailures = true) {
     this.stopProgress();
     if (this.output !== OutputLevel.silent) {
@@ -94,6 +114,27 @@ export abstract class SgCommand extends Command {
     }
   }
 
+
+  /**
+   * Loads instances of the {Project} and {ArangoStore} classes for
+   * the current project; if the current command exposes a `context`
+   * flag to override the default settings, this function will respect
+   * the custom context.
+   * 
+   * By default, this function throws an error if the Arango server
+   * can't be reached, or tthe Project configuration data is malformed.
+   * If the `returnErrors` parameter is true, it will instead return
+   * an array of errors that can be checked and optionally displayed
+   * to the user when graceful recovery is possible.
+   * 
+   * This makes it easier to create functions that use the Project and
+   * graph context *if they exist* but continue without them if they
+   * can't be loaded.
+   *
+   * @async
+   * @param {boolean} [returnErrors=false]
+   * @returns {unknown}
+   */
   async getProjectContext(returnErrors = false) {
     const errors: Error[] = [];
     let project = {} as unknown as Project;

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,3 +11,5 @@ export * from './services/index.js';
 export * from './spider/index.js';
 export * from './tools/index.js';
 export * from './reports/index.js';
+
+export * from './types.js'

--- a/src/model/edges/appears-on.ts
+++ b/src/model/edges/appears-on.ts
@@ -1,6 +1,6 @@
-import {Edge, EdgeData, Vertice, Reference, Resource} from '../index.js';
+import {Edge, EdgeConstructorOptions, Vertice, Reference, Resource} from '../index.js';
 
-export interface AppearsOnData<F extends Vertice = Vertice, T extends Vertice = Resource> extends EdgeData<F, T> {
+export interface AppearsOnConstructorOptions<F extends Vertice = Vertice, T extends Vertice = Resource> extends EdgeConstructorOptions<F, T> {
   item?: Reference<F>;
   location?: Reference<T>;
 };
@@ -8,7 +8,7 @@ export interface AppearsOnData<F extends Vertice = Vertice, T extends Vertice = 
 export class AppearsOn<F extends Vertice = Vertice, T extends Vertice = Resource> extends Edge<F, T> {
   readonly _collection = 'appears_on';
 
-  constructor(data: AppearsOnData<F, T> = {}) {
+  constructor(data: AppearsOnConstructorOptions<F, T> = {}) {
     const {item, location, ...dataForSuper} = data;
 
     dataForSuper.from ??= item;

--- a/src/model/edges/edge.ts
+++ b/src/model/edges/edge.ts
@@ -1,4 +1,4 @@
-import {Vertice, isVertice, VerticeData, Reference} from '../vertices/vertice.js';
+import {Vertice, isVertice, VerticeConstructorOptions, Reference} from '../vertices/vertice.js';
 
 export function isEdge(value: unknown): value is Edge {
   return (
@@ -8,7 +8,7 @@ export function isEdge(value: unknown): value is Edge {
   );
 }
 
-export interface EdgeData<F extends Vertice = Vertice, T extends Vertice = Vertice> extends VerticeData {
+export interface EdgeConstructorOptions<F extends Vertice = Vertice, T extends Vertice = Vertice> extends VerticeConstructorOptions {
   from?: Reference<F>;
   to?: Reference<T>;
 };
@@ -18,7 +18,7 @@ export abstract class Edge<F extends Vertice = Vertice, T extends Vertice = Vert
   _to!: string;
 
   // We accept a special-purpose
-  constructor(data: EdgeData<F, T> = {}) {
+  constructor(data: EdgeConstructorOptions<F, T> = {}) {
     const {from, to, ...dataForSuper} = data;
     super(dataForSuper);
 

--- a/src/model/edges/is-child-of.ts
+++ b/src/model/edges/is-child-of.ts
@@ -1,8 +1,8 @@
 import {Resource} from '../index.js';
 import {Vertice, Reference} from '../vertices/vertice.js';
-import {Edge, EdgeData} from './edge.js';
+import {Edge, EdgeConstructorOptions} from './edge.js';
 
-export type IsChildOfType<F extends Vertice = Resource, T extends Vertice = Resource> = EdgeData<F, T> & {
+export type IsChildOfConstructorOptions<F extends Vertice = Resource, T extends Vertice = Resource> = EdgeConstructorOptions<F, T> & {
   child?: Reference<F>;
   parent?: Reference<T>;
 };
@@ -10,7 +10,7 @@ export type IsChildOfType<F extends Vertice = Resource, T extends Vertice = Reso
 export class IsChildOf<F extends Vertice = Resource, T extends Vertice = Resource> extends Edge<F, T> {
   readonly _collection = 'is_child_of';
 
-  constructor(data: IsChildOfType<F, T> = {}) {
+  constructor(data: IsChildOfConstructorOptions<F, T> = {}) {
     const {child, parent, ...dataForSuper} = data;
 
     dataForSuper.from ??= child;

--- a/src/model/edges/is-variant-of.ts
+++ b/src/model/edges/is-variant-of.ts
@@ -1,6 +1,6 @@
-import {Edge, EdgeData, Vertice, Reference, Resource} from '../index.js';
+import {Edge, EdgeConstructorOptions, Vertice, Reference, Resource} from '../index.js';
 
-export interface IsVariantOfData<F extends Vertice = Resource, T extends Vertice = Resource> extends EdgeData<F, T> {
+export interface IsVariantOfConstructorOptions<F extends Vertice = Resource, T extends Vertice = Resource> extends EdgeConstructorOptions<F, T> {
   variant?: Reference<F>;
   original?: Reference<T>;
 };
@@ -8,7 +8,7 @@ export interface IsVariantOfData<F extends Vertice = Resource, T extends Vertice
 export class IsVariantOf<F extends Vertice = Resource, T extends Vertice = Resource> extends Edge<F, T> {
   readonly _collection = 'is_variant_of';
 
-  constructor(data: IsVariantOfData<F, T> = {}) {
+  constructor(data: IsVariantOfConstructorOptions<F, T> = {}) {
     const {variant, original, ...dataForSuper} = data;
 
     dataForSuper.from ??= variant;

--- a/src/model/edges/links-to.ts
+++ b/src/model/edges/links-to.ts
@@ -1,6 +1,6 @@
-import {Edge, EdgeData, Vertice, Reference, UniqueUrl, Resource} from '../index.js';
+import {Edge, EdgeConstructorOptions, Vertice, Reference, UniqueUrl, Resource} from '../index.js';
 
-export interface LinksToData<F extends Vertice = Resource, T extends Vertice = UniqueUrl> extends EdgeData<F, T> {
+export interface LinksToConstructorOptions<F extends Vertice = Resource, T extends Vertice = UniqueUrl> extends EdgeConstructorOptions<F, T> {
   resource?: Reference<F>;
   url?: Reference<T>;
 };
@@ -8,7 +8,7 @@ export interface LinksToData<F extends Vertice = Resource, T extends Vertice = U
 export class LinksTo<F extends Vertice = Resource, T extends Vertice = Resource> extends Edge<F, T> {
   readonly _collection = 'links_to';
 
-  constructor(data: LinksToData<F, T> = {}) {
+  constructor(data: LinksToConstructorOptions<F, T> = {}) {
     const {url, resource, ...dataForSuper} = data;
 
     dataForSuper.from ??= resource;

--- a/src/model/edges/responds-with.ts
+++ b/src/model/edges/responds-with.ts
@@ -1,6 +1,6 @@
-import {Edge, EdgeData, Vertice, Reference, UniqueUrl, Resource} from '../index.js';
+import {Edge, EdgeConstructorOptions, Vertice, Reference, UniqueUrl, Resource} from '../index.js';
 
-export interface RespondsWithData<F extends Vertice = UniqueUrl, T extends Vertice = Resource> extends EdgeData<F, T> {
+export interface RespondsWithConstructorOptions<F extends Vertice = UniqueUrl, T extends Vertice = Resource> extends EdgeConstructorOptions<F, T> {
   url?: Reference<F>;
   resource?: Reference<T>;
   redirects?: URL[] | string[];
@@ -14,7 +14,7 @@ export class RespondsWith<F extends Vertice = UniqueUrl, T extends Vertice = Res
   headers!: Record<string, string | string[] | undefined>;
   redirects!: string[];
 
-  constructor(data: RespondsWithData<F, T> = {}) {
+  constructor(data: RespondsWithConstructorOptions<F, T> = {}) {
     const {url, resource, method, redirects, headers, ...dataForSuper} = data;
 
     dataForSuper.from ??= url;

--- a/src/model/helpers/index.ts
+++ b/src/model/helpers/index.ts
@@ -1,3 +1,2 @@
 export * from './unique-url-set.js';
 export * from './uuid.js';
-export * from './properties.js';

--- a/src/model/helpers/properties.ts
+++ b/src/model/helpers/properties.ts
@@ -1,8 +1,0 @@
-/* eslint-disable */
-export { getProperty, setProperty, hasProperty, deleteProperty, deepKeys } from 'dot-prop';
-export type Properties<T = string | number | boolean> = { [property: string]: Property<T> };
-export type Property<T = string | number | boolean> =
-  | T
-  | T[]
-  | Properties<T>;
-/* eslint-enable */

--- a/src/model/helpers/unique-url-set.ts
+++ b/src/model/helpers/unique-url-set.ts
@@ -24,7 +24,7 @@ export class UniqueUrlSet extends Set<UniqueUrl> {
     const uu = this.parse(value);
     if (uu) {
       super.add(uu);
-      this.verifier.add(uu.documentId);
+      this.verifier.add(uu.key);
     } else {
       this.unparsable.add(value as string);
     }
@@ -35,7 +35,7 @@ export class UniqueUrlSet extends Set<UniqueUrl> {
   override has(value: ValidUniqueUrlInput): boolean {
     const uu = this.parse(value);
     if (uu) {
-      return this.verifier.has(uu.documentId);
+      return this.verifier.has(uu.key);
     }
 
     return false;
@@ -44,9 +44,9 @@ export class UniqueUrlSet extends Set<UniqueUrl> {
   override delete(value: ValidUniqueUrlInput): boolean {
     const uu = this.parse(value);
     if (uu) {
-      this.verifier.delete(uu.documentId);
+      this.verifier.delete(uu.key);
       for (const u of this) {
-        if (u.documentId === uu.documentId) {
+        if (u.key === uu.key) {
           super.delete(u);
         }
       }

--- a/src/model/vertices/dataset.ts
+++ b/src/model/vertices/dataset.ts
@@ -1,6 +1,6 @@
-import {Vertice, VerticeData} from './vertice.js';
+import {Vertice, VerticeConstructorOptions} from './vertice.js';
 
-export interface DataSetData<DataInterface = unknown> extends VerticeData {
+export interface DataSetConstructorOptions<DataInterface = unknown> extends VerticeConstructorOptions {
   name: string;
   data: DataInterface;
 };
@@ -41,9 +41,9 @@ export class DataSet<DataInterface = unknown> extends Vertice {
    * Creates an instance of DataSet.
    *
    * @constructor
-   * @param {DataSetData<DataInterface>} input
+   * @param {DataSetConstructorOptions<DataInterface>} input
    */
-  constructor(input: DataSetData<DataInterface>) {
+  constructor(input: DataSetConstructorOptions<DataInterface>) {
     const {name, data, ...dataForSuper} = input;
     super(dataForSuper);
 

--- a/src/model/vertices/fragment.ts
+++ b/src/model/vertices/fragment.ts
@@ -1,6 +1,6 @@
-import {Vertice, VerticeData, Reference} from '../index.js';
+import {Vertice, VerticeConstructorOptions, Reference} from '../index.js';
 
-export interface FragmentData extends VerticeData {
+export interface FragmentConstructorOptions extends VerticeConstructorOptions {
   location?: Reference;
 };
 
@@ -28,9 +28,9 @@ export class Fragment extends Vertice {
    * Creates an instance of a Fragment, with an optional connection to an existing graph Entity.
    *
    * @constructor
-   * @param {FragmentData} input
+   * @param {FragmentConstructorOptions} input
    */
-  constructor(input: FragmentData) {
+  constructor(input: FragmentConstructorOptions) {
     const {location, ...dataForSuper} = input;
     super(dataForSuper);
 

--- a/src/model/vertices/resource.ts
+++ b/src/model/vertices/resource.ts
@@ -1,9 +1,9 @@
 import { ParsedUrl } from '@autogram/url-tools';
 import is from '@sindresorhus/is';
-import {Vertice, VerticeData, Expose, Transform} from './vertice.js';
+import {Vertice, VerticeConstructorOptions, Expose, Transform} from './vertice.js';
 import {parse as parseContentType} from 'content-type';
 
-export interface ResourceData extends VerticeData {
+export interface ResourceConstructorOptions extends VerticeConstructorOptions {
   url?: string | URL;
   code?: number | string;
   message?: string;
@@ -28,7 +28,7 @@ export class Resource extends Vertice {
   body?: string;
   files!: SavedFile[];
 
-  constructor(data: ResourceData = {}) {
+  constructor(data: ResourceConstructorOptions = {}) {
     const {url, parsed, code, message, headers, mime, size, body, files, ...dataForSuper} = data;
     super(dataForSuper);
 

--- a/src/model/vertices/unique-url.ts
+++ b/src/model/vertices/unique-url.ts
@@ -1,9 +1,9 @@
 import {URL} from 'node:url';
 import is from '@sindresorhus/is';
 import {NormalizedUrl, UrlMutators} from '@autogram/url-tools';
-import {Vertice, VerticeData, Transform} from './vertice.js';
+import {Vertice, VerticeConstructorOptions, Transform} from './vertice.js';
 
-export interface UniqueUrlData extends VerticeData {
+export interface UniqueUrlConstructorOptions extends VerticeConstructorOptions {
   url?: string | NormalizedUrl;
   source?: UrlSource;
   base?: string | URL;
@@ -54,7 +54,7 @@ export class UniqueUrl extends Vertice {
     return this.parsed !== undefined;
   }
 
-  constructor(data: UniqueUrlData = {}) {
+  constructor(data: UniqueUrlConstructorOptions = {}) {
     let {url, base, normalizer, referer, depth, ...dataForSuper} = data;
     super(dataForSuper);
 

--- a/src/model/vertices/vertice.ts
+++ b/src/model/vertices/vertice.ts
@@ -95,7 +95,7 @@ export abstract class Vertice {
       typeof data === 'string' ? ensureJsonMap(JSON.parse(data)) : data
     );
 
-    if (((has(object, '_id') || has(object, ['_collection', '_key'])))) {
+    if (has(object, ['_collection'])) {
       const ctor = Vertice.types.get(object._collection as string)?.constructor;
       if (ctor) {
         return plainToInstance(
@@ -106,7 +106,7 @@ export abstract class Vertice {
       }
     }
 
-    throw new TypeError('Vertices require collection and key or id');
+    throw new TypeError('Vertice data has no _collection property');
   }
 
   toJSON(): JsonMap {

--- a/src/reports/link-summaries.ts
+++ b/src/reports/link-summaries.ts
@@ -149,14 +149,14 @@ export const LinkSummaries = {
 
     LET inlinks = (
         FOR lt IN links_to
-        FILTER lt._to == u._id
+        FILTER lt._to == uu._id
         RETURN DISTINCT lt.href
     )
     FILTER LENGTH(inlinks) > 1
     SORT LENGTH(inlinks) DESC
     RETURN {
-        domain: u.parsed.domain,
-        url: u.url,
+        domain: uu.parsed.domain,
+        url: uu.url,
         inlinks
     }`
   }

--- a/src/reports/link-summaries.ts
+++ b/src/reports/link-summaries.ts
@@ -119,6 +119,10 @@ export const LinkSummaries = {
   `;
   },
 
+
+  /**
+   * A list of all 30x redirects encountered during the crawl
+   */
   redirects() {
     return aql`
     for u in unique_urls
@@ -133,4 +137,27 @@ export const LinkSummaries = {
   `;
   },
 
+  /**
+   * A list of every UniqueUrl whose inbound links contain more
+   * than one distinct HREF value. This can be used to find important
+   * querystring parameters or path elements that are being discared
+   * by an overly-aggressive URL Normalizer.  
+   */
+  normalized() {
+    return aql`
+    FOR uu IN unique_urls
+
+    LET inlinks = (
+        FOR lt IN links_to
+        FILTER lt._to == u._id
+        RETURN DISTINCT lt.href
+    )
+    FILTER LENGTH(inlinks) > 1
+    SORT LENGTH(inlinks) DESC
+    RETURN {
+        domain: u.parsed.domain,
+        url: u.url,
+        inlinks
+    }`
+  }
 };

--- a/src/services/arango-store.ts
+++ b/src/services/arango-store.ts
@@ -6,7 +6,7 @@ import {DocumentMetadata} from 'arangojs/documents.js';
 import {DocumentCollection} from 'arangojs/collection.js';
 import arrify from 'arrify';
 import slugify from '@sindresorhus/slugify';
-import {Vertice, VerticeData, isEdge, UniqueUrl, RespondsWith, Resource, LinksTo, IsChildOf, IsVariantOf, AppearsOn, DataSet, Fragment} from '../model/index.js';
+import {Vertice, Reference, VerticeData, isEdge, UniqueUrl, RespondsWith, Resource, LinksTo, IsChildOf, IsVariantOf, AppearsOn, DataSet, Fragment} from '../model/index.js';
 import { Project } from './project.js';
 
 export {aql} from 'arangojs';
@@ -144,8 +144,13 @@ export class ArangoStore {
    * Convenience wrappers for saving and deleting Spidergram Entities
    */
 
-  async get<T extends Vertice = Vertice>(id: string): Promise<T | undefined> {
-    const [collection, key] = id.split('/');
+  async exists(ref: Reference) : Promise<boolean> {
+    const [collection, key] = Vertice.idFromReference(ref).split('/');
+    return this.db.collection(collection).documentExists(key);
+  }
+
+  async get<T extends Vertice = Vertice>(ref: Reference): Promise<T | undefined> {
+    const [collection, key] = Vertice.idFromReference(ref).split('/');
     return this.db.collection<VerticeData>(collection).document(key)
       .then(json => Vertice.fromJSON(json) as T)
       .catch(() => undefined);

--- a/src/services/arango-store.ts
+++ b/src/services/arango-store.ts
@@ -6,8 +6,9 @@ import {DocumentMetadata} from 'arangojs/documents.js';
 import {DocumentCollection} from 'arangojs/collection.js';
 import arrify from 'arrify';
 import slugify from '@sindresorhus/slugify';
-import {Vertice, Reference, VerticeData, isEdge, UniqueUrl, RespondsWith, Resource, LinksTo, IsChildOf, IsVariantOf, AppearsOn, DataSet, Fragment} from '../model/index.js';
+import {Vertice, Reference, isEdge, UniqueUrl, RespondsWith, Resource, LinksTo, IsChildOf, IsVariantOf, AppearsOn, DataSet, Fragment} from '../model/index.js';
 import { Project } from './project.js';
+import { JsonMap } from '@salesforce/ts-types'
 
 export {aql} from 'arangojs';
 
@@ -151,7 +152,7 @@ export class ArangoStore {
 
   async get<T extends Vertice = Vertice>(ref: Reference): Promise<T | undefined> {
     const [collection, key] = Vertice.idFromReference(ref).split('/');
-    return this.db.collection<VerticeData>(collection).document(key)
+    return this.db.collection<JsonMap>(collection).document(key)
       .then(json => Vertice.fromJSON(json) as T)
       .catch(() => undefined);
   }

--- a/src/services/graph-worker.ts
+++ b/src/services/graph-worker.ts
@@ -1,7 +1,7 @@
 import EventEmitter from 'node:events';
 import {AqlQuery} from 'arangojs/aql.js';
 import is from '@sindresorhus/is';
-import {JsonObject} from 'type-fest';
+import {JsonMap} from '@salesforce/ts-types';
 import {Project, Vertice, aql, ProjectConfig, ArangoStore, JobStatus} from '../index.js';
 
 export type GraphWorkerTask<T extends Vertice = Vertice> = (item: T) => Promise<void>;
@@ -62,7 +62,7 @@ export class GraphWorker<T extends Vertice = Vertice> extends EventEmitter {
         return item
       `;
 
-      return graph.query<JsonObject>(query, {count: true, batchSize: 10})
+      return graph.query<JsonMap>(query, {count: true, batchSize: 10})
         .then(async cursor => {
           this.status.total = cursor.count ?? 0;
           for await (const batch of cursor.batches) {

--- a/src/services/url-hierarchy-builder.ts
+++ b/src/services/url-hierarchy-builder.ts
@@ -3,7 +3,7 @@ import is from '@sindresorhus/is';
 import {GeneratedAqlQuery} from 'arangojs/aql';
 import {Vertice, Edge, UniqueUrl, IsChildOf, UrlSource, ArangoStore, aql} from '../index.js';
 import {ParsedUrl} from '@autogram/url-tools';
-import {JsonObject} from 'type-fest';
+import {JsonMap} from '@salesforce/ts-types';
 
 
 export interface HierarchyData<V extends Vertice = Vertice, E extends Edge = Edge> {
@@ -46,7 +46,7 @@ export class UrlHierarchyBuilder {
   // can be passed in, but should use the `aql` template literal
   // function rather than raw strings.
   async loadPool<V>(filter?: GeneratedAqlQuery): Promise<void> {
-    const cursor = await this.graph.query(
+    const cursor = await this.graph.query<JsonMap>(
       aql`
         FOR item in unique_urls
           FILTER item.parsed != null
@@ -54,7 +54,7 @@ export class UrlHierarchyBuilder {
           ${filter}
           return item`,
     );
-    await cursor.map(result => UniqueUrl.fromJSON(result as JsonObject))
+    await cursor.map(result => UniqueUrl.fromJSON(result))
       .then(urls => {
         this.pool = urls;
       })

--- a/src/spider/links/find-urls.ts
+++ b/src/spider/links/find-urls.ts
@@ -27,7 +27,7 @@ export async function find(
         ) {
           results.push({
             href,
-            text: $(element).text(),
+            text: $(element).text().trim(),
             label,
             selector,
             attributes,

--- a/src/spider/links/utils.ts
+++ b/src/spider/links/utils.ts
@@ -118,6 +118,18 @@ export interface EnqueueUrlOptions {
   requestQueue?: RequestQueue;
 
   /**
+   * Don't save or enqueue the link if it already exists in the graph.
+   *
+   * *NOTE:* Only affects the saving and enqueuing of {@apilink UniqueUrl} 
+   * objects themselves; LinksTo records connection crawled Resources to
+   * the UniqueUrl may still be created. 
+   *
+   * @type {boolean}
+   * @default true
+   */
+  discardExistingLinks?: boolean;
+
+  /**
    * A label applied to any {@apilink LinksTo} objects created when the
    * URLs are saved to the project graph. This can be used in conjunction
    * with a restrictive selector to record which links appeared in body
@@ -145,6 +157,7 @@ const urlDiscoveryDefaultOptions: EnqueueUrlOptions = {
   skipAnchors: true,
   skipNonWebLinks: false,
   skipUnparsableLinks: false,
+  discardExistingLinks: true,
 };
 
 export type AnchorTagData = {

--- a/src/tools/google/universal-analytics.ts
+++ b/src/tools/google/universal-analytics.ts
@@ -220,9 +220,9 @@ export function buildUaRequest(viewId: string, customOptions: Partial<UaRequestO
  * specified dateWindow, much like the 'page' of a paged result set.
  *
  * @export
- * @param {DateWindow} [window='month'] The span of time the range should cover.
- * @param {number} [offset=-1] The span's offset from the current day.
- * @param {today} [DateTime.local()] Optional override for the 'current day'; useful for testing.
+ * @param window The span of time the range should cover.
+ * @param offset The span's offset from the current day.
+ * @param today Optional override for the 'current day'; primarily intended for testing.
  */
 export function buildDateRange(window: DateWindow = 'month', offset = -1, today = DateTime.local()): { startDate: string, endDate: string} {
   // Prep the starting points

--- a/src/tools/google/universal-analytics.ts
+++ b/src/tools/google/universal-analytics.ts
@@ -36,6 +36,8 @@ export interface UaRequestOptions {
 
   /**
    * The unit of time covered by the report.
+   * 
+   * @see {@link buildDateRange}
    *
    * @defaultValue {'month'}
    * @type {DateWindow}
@@ -46,16 +48,7 @@ export interface UaRequestOptions {
    * Used in conjunction with `dateWindow` to calculate the report's start
    * and end date.
    * 
-   * A dateOffset of -1 will generate a range starting one dateWindow ago, and
-   * ending yesterday. (e.g., on November 10th a window of 'month' and an
-   * offset of '-1' would generate a report for Oct9-Nov9.)
-   * 
-   * A dateOffset of 0 will generate a range covering the most recent complete
-   * dateWindow. (e.g., on November 10th a window of 'month' and and
-   * offset of '0' would generate a report for Oct1-Oct31.)
-   * 
-   * Incrementing the dateOffset (1, 2, 3, etc) moves back in time by the
-   * specified dateWindow, much like the 'page' of a paged result set.
+   * @see {@link buildDateRange}
    *
    * @defaultValue {-1}
    * @type {number}
@@ -212,7 +205,26 @@ export function buildUaRequest(viewId: string, customOptions: Partial<UaRequestO
   return request;
 }
 
-export function buildDateRange(window: DateWindow = 'month', offset = -1, today = DateTime.local()) {
+/**
+ * Given a unit of time and an offset, generates start and end ISO dates.
+ * 
+ * A dateOffset of -1 will generate a range starting one dateWindow ago, and
+ * ending yesterday. (e.g., on November 10th a window of 'month' and an
+ * offset of '-1' would generate a report for Oct9-Nov9.)
+ * 
+ * A dateOffset of 0 will generate a range covering the most recent complete
+ * dateWindow. (e.g., on November 10th a window of 'month' and and
+ * offset of '0' would generate a report for Oct1-Oct31.)
+ * 
+ * Incrementing the dateOffset (1, 2, 3, etc) moves back in time by the
+ * specified dateWindow, much like the 'page' of a paged result set.
+ *
+ * @export
+ * @param {DateWindow} [window='month'] The span of time the range should cover.
+ * @param {number} [offset=-1] The span's offset from the current day.
+ * @param {today} [DateTime.local()] Optional override for the 'current day'; useful for testing.
+ */
+export function buildDateRange(window: DateWindow = 'month', offset = -1, today = DateTime.local()): { startDate: string, endDate: string} {
   // Prep the starting points
   let start = today.minus({ days: 1 });
   let end = today.minus({ days: 1 });

--- a/src/tools/html.ts
+++ b/src/tools/html.ts
@@ -2,30 +2,14 @@ import is from '@sindresorhus/is';
 import * as htmlparser2 from "htmlparser2";
 import { Handler, Result as HtmlMetaResult } from "htmlmetaparser";
 import * as cheerio from 'cheerio';
-
 import { htmlToText, HtmlToTextOptions } from 'html-to-text';
+import { Resource } from '../model/index.js';
 
-import { Properties } from '../model/helpers/properties.js';
 
 export { social as getSocialLinks, parseOpenGraph as getOpenGraph } from 'crawlee';
-import { Resource } from '../model/index.js';
 
 export function getPlainText(html: string, options?: HtmlToTextOptions): string {
   return htmlToText(html, options);
-}
-
-export function parseFeed(
-  feed: string | Buffer,
-  options?: Parameters<typeof htmlparser2.parseFeed>[1]
-  ) {
-  return htmlparser2.parseDocument(feed.toString());
-}
-
-export function getDocument(
-  html: string | Buffer,
-  options?: Parameters<typeof htmlparser2.parseDocument>[1]
-  ) {
-  return htmlparser2.parseDocument(html.toString());
 }
 
 export function parseWithCheerio(
@@ -65,12 +49,12 @@ export function getMetadata(input: string | Resource, baseUrl?: string) {
   }
 }
 
-export function getBodyAttributes(input: string | cheerio.Root): Properties<string> {
+export function getBodyAttributes(input: string | cheerio.Root) {
   const $ = is.string(input) ? parseWithCheerio(input) : input;
-  let results: Properties<string> = { ...$('body').attr() };
-  if ('class' in results) {
-    results.class = results.class?.toString().replace(/\s+/, ' ').split(' ');
+  let output: Record<string, string | string[]> = { ...$('body').attr() };
+  if ('class' in output) {
+    output.class = output.class?.toString().replace(/\s+/, ' ').split(' ');
   }
-  return results;
+  return output;
 }
 

--- a/src/tools/html.ts
+++ b/src/tools/html.ts
@@ -8,7 +8,6 @@ import { htmlToText, HtmlToTextOptions } from 'html-to-text';
 import { Properties } from '../model/helpers/properties.js';
 
 export { social as getSocialLinks, parseOpenGraph as getOpenGraph } from 'crawlee';
-import { Thing, Graph as SchemaGraph } from "schema-dts";
 import { Resource } from '../model/index.js';
 
 export function getPlainText(html: string, options?: HtmlToTextOptions): string {
@@ -64,42 +63,6 @@ export function getMetadata(input: string | Resource, baseUrl?: string) {
     }
     return output;
   }
-}
-
-// We'll want to deprecate this; Properties in particular is jank; a relic of some 
-// bad JSON-parsing practices from early in the project.
-export function getMetaTags(input: string | cheerio.Root): Properties<string> {
-  const $ = is.string(input) ? parseWithCheerio(input) : input;
-  const results: Record<string, string> = {};
-
-  $('head meta').each((index, tag) => {
-    const k = $(tag).attr('name') || $(tag).attr('property') || $(tag).attr('itemprop')
-    const v = $(tag).attr('content')  
-    if (k && v) results[k] = v;
-  });
-
-  const title = $('head title').text().toString();
-  if (title) results.title = title;
-
-  return results;
-}
-
-// Right now this only works with a single @graph element. Later we'll want to graph
-// any JSON-LD chunks and turn them into an array.
-export function getSchemaOrg(input: string | cheerio.Root): readonly Thing[] {
-  const $ = is.string(input) ? parseWithCheerio(input) : input;
-  let results: readonly Thing[] = [];
-  try {
-    $('script[type=application/ld+json]').each((index, element) => {
-      const json = JSON.parse($(element).text()) as SchemaGraph;
-      if ('@context' in json && json["@context"] == 'https://schema.org') {
-        results = json["@graph"];
-      }  
-    })
-  } catch {
-    results = [];
-  }
-  return results;
 }
 
 export function getBodyAttributes(input: string | cheerio.Root): Properties<string> {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,6 +1,7 @@
 export * as TextTools from './text.js';
 export * as HtmlTools from './html.js';
 export * as GoogleTools from './google/index.js';
+export * as PageUtils from './page.js';
 
 export * from './screenshot.js';
 export * from './spreadsheet.js';

--- a/src/tools/page.ts
+++ b/src/tools/page.ts
@@ -1,0 +1,6 @@
+import { Page } from 'playwright';
+
+export async function getGoogleTagData(page: Page) {
+  return page.evaluate<unknown[]>('() => JSON.parse(JSON.stringify(window.dataLayer ?? []))');
+}
+

--- a/src/tools/spreadsheet.ts
+++ b/src/tools/spreadsheet.ts
@@ -4,6 +4,7 @@ import {Readable} from 'node:stream';
 import is from '@sindresorhus/is';
 import * as XLSX from 'xlsx';
 import {JsonPrimitive} from 'type-fest';
+import { Buffer } from 'node:buffer';
 
 XLSX.set_fs(fs);
 XLSX.stream.set_readable(Readable);
@@ -28,10 +29,12 @@ export type SheetData = RowData[];
 export type RowData = Record<string, CellValue>;
 export type CellValue = JsonPrimitive;
 
-type SpreadsheetSaveOptions = {
+type SpreadsheetWriteOptions = {
   format: XLSX.BookType;
   compression: boolean;
 };
+
+type SpreadsheetGenerateOptions = Omit<XLSX.WritingOptions, 'type'>;
 
 export class Spreadsheet {
   static utils = XLSX.utils;
@@ -60,8 +63,8 @@ export class Spreadsheet {
     }
   }
 
-  async save(filename: string, customOptions: Partial<SpreadsheetSaveOptions> = {}): Promise<string> {
-    const options: SpreadsheetSaveOptions = {
+  async save(filename: string, customOptions: Partial<SpreadsheetWriteOptions> = {}): Promise<string> {
+    const options: SpreadsheetWriteOptions = {
       format: 'xlsx',
       compression: true,
       ...customOptions,
@@ -79,5 +82,15 @@ export class Spreadsheet {
         reject(error);
       }
     });
+  }
+
+  generate(customOptions: Partial<SpreadsheetGenerateOptions> = {}): Buffer {
+    const options = {
+      format: 'xlsx',
+      compression: true,
+      ...customOptions,
+    };
+
+    return XLSX.write(this.workbook, { ...options, type: 'buffer' }) as Buffer;
   }
 }

--- a/src/tools/spreadsheet.ts
+++ b/src/tools/spreadsheet.ts
@@ -3,7 +3,7 @@ import * as fs from 'node:fs';
 import {Readable} from 'node:stream';
 import is from '@sindresorhus/is';
 import * as XLSX from 'xlsx';
-import {JsonPrimitive} from 'type-fest';
+import {JsonPrimitive} from '@salesforce/ts-types';
 import { Buffer } from 'node:buffer';
 
 XLSX.set_fs(fs);
@@ -24,10 +24,11 @@ XLSX.stream.set_readable(Readable);
  * Named columns: { col1: 'some data', col2: 123, ... }
  * Array of values: [ 'some data', 123 ]
  */
-export type SpreadsheetData = Record<string, SheetData> | SheetData[];
-export type SheetData = RowData[];
-export type RowData = Record<string, CellValue>;
-export type CellValue = JsonPrimitive;
+
+type Workbook = Sheet[] | Record<string, Sheet>;
+type Sheet = Row[];
+type Row = Record<string, Cell>;
+type Cell = JsonPrimitive
 
 type SpreadsheetWriteOptions = {
   format: XLSX.BookType;
@@ -41,7 +42,7 @@ export class Spreadsheet {
 
   workbook: XLSX.WorkBook;
 
-  constructor(data?: SpreadsheetData) {
+  constructor(data?: Workbook) {
     const {utils} = Spreadsheet;
     this.workbook = utils.book_new();
     if (!is.undefined(data)) {
@@ -57,7 +58,7 @@ export class Spreadsheet {
     }
   }
 
-  addSheet(data: SheetData, name?: string) {
+  addSheet(data: Sheet | Cell[], name?: string) {
     if (is.array(data)) {
       name = Spreadsheet.utils.book_append_sheet(this.workbook, XLSX.utils.json_to_sheet(data), name);
     }


### PR DESCRIPTION
Eliminates the `type-fest` dependency in favor of `@salesforce/ts-types`; the former covers far more ground with exotic type definitions than we need, and our primary use for it was the `JsonObject` collection of types. the Salesforce library covers the same with its `AnyJson` type, and also provides a collection of coercion and validation functions that eliminate quite a bit of parsed-json-validation boilerplate code.

This is related to #24; the full `@salesforce/kit` library may useful in the future, but for now we'll just adopt `ts-types.`