### PR TITLE
Dependency cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "@autogram/url-tools": "^2.5.2",
     "@oclif/plugin-help": "^5",
     "@oclif/plugin-plugins": "^2.1.6",
+    "@salesforce/ts-types": "^1.7.1",
     "@sindresorhus/is": "^5.3.0",
     "@sindresorhus/slugify": "^2.1.1",
     "@vladfrangu/async_event_emitter": "^2.1.2",
@@ -93,7 +94,6 @@
     "read-pkg-up": "^9.1.0",
     "reflect-metadata": "^0.1.13",
     "terminal-link": "^3.0.0",
-    "type-fest": "^3.1.0",
     "typefs": "^1.1.147",
     "uuid": "^9.0.0"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,3 +11,5 @@ export * from './services/index.js';
 export * from './spider/index.js';
 export * from './tools/index.js';
 export * from './reports/index.js';
+
+export * from './types.js'

--- a/src/model/edges/appears-on.ts
+++ b/src/model/edges/appears-on.ts
@@ -1,6 +1,6 @@
-import {Edge, EdgeData, Vertice, Reference, Resource} from '../index.js';
+import {Edge, EdgeConstructorOptions, Vertice, Reference, Resource} from '../index.js';
 
-export interface AppearsOnData<F extends Vertice = Vertice, T extends Vertice = Resource> extends EdgeData<F, T> {
+export interface AppearsOnConstructorOptions<F extends Vertice = Vertice, T extends Vertice = Resource> extends EdgeConstructorOptions<F, T> {
   item?: Reference<F>;
   location?: Reference<T>;
 };
@@ -8,7 +8,7 @@ export interface AppearsOnData<F extends Vertice = Vertice, T extends Vertice = 
 export class AppearsOn<F extends Vertice = Vertice, T extends Vertice = Resource> extends Edge<F, T> {
   readonly _collection = 'appears_on';
 
-  constructor(data: AppearsOnData<F, T> = {}) {
+  constructor(data: AppearsOnConstructorOptions<F, T> = {}) {
     const {item, location, ...dataForSuper} = data;
 
     dataForSuper.from ??= item;

--- a/src/model/edges/edge.ts
+++ b/src/model/edges/edge.ts
@@ -1,4 +1,4 @@
-import {Vertice, isVertice, VerticeData, Reference} from '../vertices/vertice.js';
+import {Vertice, isVertice, VerticeConstructorOptions, Reference} from '../vertices/vertice.js';
 
 export function isEdge(value: unknown): value is Edge {
   return (
@@ -8,7 +8,7 @@ export function isEdge(value: unknown): value is Edge {
   );
 }
 
-export interface EdgeData<F extends Vertice = Vertice, T extends Vertice = Vertice> extends VerticeData {
+export interface EdgeConstructorOptions<F extends Vertice = Vertice, T extends Vertice = Vertice> extends VerticeConstructorOptions {
   from?: Reference<F>;
   to?: Reference<T>;
 };
@@ -18,7 +18,7 @@ export abstract class Edge<F extends Vertice = Vertice, T extends Vertice = Vert
   _to!: string;
 
   // We accept a special-purpose
-  constructor(data: EdgeData<F, T> = {}) {
+  constructor(data: EdgeConstructorOptions<F, T> = {}) {
     const {from, to, ...dataForSuper} = data;
     super(dataForSuper);
 

--- a/src/model/edges/is-child-of.ts
+++ b/src/model/edges/is-child-of.ts
@@ -1,8 +1,8 @@
 import {Resource} from '../index.js';
 import {Vertice, Reference} from '../vertices/vertice.js';
-import {Edge, EdgeData} from './edge.js';
+import {Edge, EdgeConstructorOptions} from './edge.js';
 
-export type IsChildOfType<F extends Vertice = Resource, T extends Vertice = Resource> = EdgeData<F, T> & {
+export type IsChildOfConstructorOptions<F extends Vertice = Resource, T extends Vertice = Resource> = EdgeConstructorOptions<F, T> & {
   child?: Reference<F>;
   parent?: Reference<T>;
 };
@@ -10,7 +10,7 @@ export type IsChildOfType<F extends Vertice = Resource, T extends Vertice = Reso
 export class IsChildOf<F extends Vertice = Resource, T extends Vertice = Resource> extends Edge<F, T> {
   readonly _collection = 'is_child_of';
 
-  constructor(data: IsChildOfType<F, T> = {}) {
+  constructor(data: IsChildOfConstructorOptions<F, T> = {}) {
     const {child, parent, ...dataForSuper} = data;
 
     dataForSuper.from ??= child;

--- a/src/model/edges/is-variant-of.ts
+++ b/src/model/edges/is-variant-of.ts
@@ -1,6 +1,6 @@
-import {Edge, EdgeData, Vertice, Reference, Resource} from '../index.js';
+import {Edge, EdgeConstructorOptions, Vertice, Reference, Resource} from '../index.js';
 
-export interface IsVariantOfData<F extends Vertice = Resource, T extends Vertice = Resource> extends EdgeData<F, T> {
+export interface IsVariantOfConstructorOptions<F extends Vertice = Resource, T extends Vertice = Resource> extends EdgeConstructorOptions<F, T> {
   variant?: Reference<F>;
   original?: Reference<T>;
 };
@@ -8,7 +8,7 @@ export interface IsVariantOfData<F extends Vertice = Resource, T extends Vertice
 export class IsVariantOf<F extends Vertice = Resource, T extends Vertice = Resource> extends Edge<F, T> {
   readonly _collection = 'is_variant_of';
 
-  constructor(data: IsVariantOfData<F, T> = {}) {
+  constructor(data: IsVariantOfConstructorOptions<F, T> = {}) {
     const {variant, original, ...dataForSuper} = data;
 
     dataForSuper.from ??= variant;

--- a/src/model/edges/links-to.ts
+++ b/src/model/edges/links-to.ts
@@ -1,6 +1,6 @@
-import {Edge, EdgeData, Vertice, Reference, UniqueUrl, Resource} from '../index.js';
+import {Edge, EdgeConstructorOptions, Vertice, Reference, UniqueUrl, Resource} from '../index.js';
 
-export interface LinksToData<F extends Vertice = Resource, T extends Vertice = UniqueUrl> extends EdgeData<F, T> {
+export interface LinksToConstructorOptions<F extends Vertice = Resource, T extends Vertice = UniqueUrl> extends EdgeConstructorOptions<F, T> {
   resource?: Reference<F>;
   url?: Reference<T>;
 };
@@ -8,7 +8,7 @@ export interface LinksToData<F extends Vertice = Resource, T extends Vertice = U
 export class LinksTo<F extends Vertice = Resource, T extends Vertice = Resource> extends Edge<F, T> {
   readonly _collection = 'links_to';
 
-  constructor(data: LinksToData<F, T> = {}) {
+  constructor(data: LinksToConstructorOptions<F, T> = {}) {
     const {url, resource, ...dataForSuper} = data;
 
     dataForSuper.from ??= resource;

--- a/src/model/edges/responds-with.ts
+++ b/src/model/edges/responds-with.ts
@@ -1,6 +1,6 @@
-import {Edge, EdgeData, Vertice, Reference, UniqueUrl, Resource} from '../index.js';
+import {Edge, EdgeConstructorOptions, Vertice, Reference, UniqueUrl, Resource} from '../index.js';
 
-export interface RespondsWithData<F extends Vertice = UniqueUrl, T extends Vertice = Resource> extends EdgeData<F, T> {
+export interface RespondsWithConstructorOptions<F extends Vertice = UniqueUrl, T extends Vertice = Resource> extends EdgeConstructorOptions<F, T> {
   url?: Reference<F>;
   resource?: Reference<T>;
   redirects?: URL[] | string[];
@@ -14,7 +14,7 @@ export class RespondsWith<F extends Vertice = UniqueUrl, T extends Vertice = Res
   headers!: Record<string, string | string[] | undefined>;
   redirects!: string[];
 
-  constructor(data: RespondsWithData<F, T> = {}) {
+  constructor(data: RespondsWithConstructorOptions<F, T> = {}) {
     const {url, resource, method, redirects, headers, ...dataForSuper} = data;
 
     dataForSuper.from ??= url;

--- a/src/model/helpers/index.ts
+++ b/src/model/helpers/index.ts
@@ -1,3 +1,2 @@
 export * from './unique-url-set.js';
 export * from './uuid.js';
-export * from './properties.js';

--- a/src/model/helpers/properties.ts
+++ b/src/model/helpers/properties.ts
@@ -1,8 +1,0 @@
-/* eslint-disable */
-export { getProperty, setProperty, hasProperty, deleteProperty, deepKeys } from 'dot-prop';
-export type Properties<T = string | number | boolean> = { [property: string]: Property<T> };
-export type Property<T = string | number | boolean> =
-  | T
-  | T[]
-  | Properties<T>;
-/* eslint-enable */

--- a/src/model/helpers/unique-url-set.ts
+++ b/src/model/helpers/unique-url-set.ts
@@ -24,7 +24,7 @@ export class UniqueUrlSet extends Set<UniqueUrl> {
     const uu = this.parse(value);
     if (uu) {
       super.add(uu);
-      this.verifier.add(uu.documentId);
+      this.verifier.add(uu.key);
     } else {
       this.unparsable.add(value as string);
     }
@@ -35,7 +35,7 @@ export class UniqueUrlSet extends Set<UniqueUrl> {
   override has(value: ValidUniqueUrlInput): boolean {
     const uu = this.parse(value);
     if (uu) {
-      return this.verifier.has(uu.documentId);
+      return this.verifier.has(uu.key);
     }
 
     return false;
@@ -44,9 +44,9 @@ export class UniqueUrlSet extends Set<UniqueUrl> {
   override delete(value: ValidUniqueUrlInput): boolean {
     const uu = this.parse(value);
     if (uu) {
-      this.verifier.delete(uu.documentId);
+      this.verifier.delete(uu.key);
       for (const u of this) {
-        if (u.documentId === uu.documentId) {
+        if (u.key === uu.key) {
           super.delete(u);
         }
       }

--- a/src/model/vertices/dataset.ts
+++ b/src/model/vertices/dataset.ts
@@ -1,6 +1,6 @@
-import {Vertice, VerticeData} from './vertice.js';
+import {Vertice, VerticeConstructorOptions} from './vertice.js';
 
-export interface DataSetData<DataInterface = unknown> extends VerticeData {
+export interface DataSetConstructorOptions<DataInterface = unknown> extends VerticeConstructorOptions {
   name: string;
   data: DataInterface;
 };
@@ -41,9 +41,9 @@ export class DataSet<DataInterface = unknown> extends Vertice {
    * Creates an instance of DataSet.
    *
    * @constructor
-   * @param {DataSetData<DataInterface>} input
+   * @param {DataSetConstructorOptions<DataInterface>} input
    */
-  constructor(input: DataSetData<DataInterface>) {
+  constructor(input: DataSetConstructorOptions<DataInterface>) {
     const {name, data, ...dataForSuper} = input;
     super(dataForSuper);
 

--- a/src/model/vertices/fragment.ts
+++ b/src/model/vertices/fragment.ts
@@ -1,6 +1,6 @@
-import {Vertice, VerticeData, Reference} from '../index.js';
+import {Vertice, VerticeConstructorOptions, Reference} from '../index.js';
 
-export interface FragmentData extends VerticeData {
+export interface FragmentConstructorOptions extends VerticeConstructorOptions {
   location?: Reference;
 };
 
@@ -28,9 +28,9 @@ export class Fragment extends Vertice {
    * Creates an instance of a Fragment, with an optional connection to an existing graph Entity.
    *
    * @constructor
-   * @param {FragmentData} input
+   * @param {FragmentConstructorOptions} input
    */
-  constructor(input: FragmentData) {
+  constructor(input: FragmentConstructorOptions) {
     const {location, ...dataForSuper} = input;
     super(dataForSuper);
 

--- a/src/model/vertices/resource.ts
+++ b/src/model/vertices/resource.ts
@@ -1,9 +1,9 @@
 import { ParsedUrl } from '@autogram/url-tools';
 import is from '@sindresorhus/is';
-import {Vertice, VerticeData, Expose, Transform} from './vertice.js';
+import {Vertice, VerticeConstructorOptions, Expose, Transform} from './vertice.js';
 import {parse as parseContentType} from 'content-type';
 
-export interface ResourceData extends VerticeData {
+export interface ResourceConstructorOptions extends VerticeConstructorOptions {
   url?: string | URL;
   code?: number | string;
   message?: string;
@@ -28,7 +28,7 @@ export class Resource extends Vertice {
   body?: string;
   files!: SavedFile[];
 
-  constructor(data: ResourceData = {}) {
+  constructor(data: ResourceConstructorOptions = {}) {
     const {url, parsed, code, message, headers, mime, size, body, files, ...dataForSuper} = data;
     super(dataForSuper);
 

--- a/src/model/vertices/unique-url.ts
+++ b/src/model/vertices/unique-url.ts
@@ -1,9 +1,9 @@
 import {URL} from 'node:url';
 import is from '@sindresorhus/is';
 import {NormalizedUrl, UrlMutators} from '@autogram/url-tools';
-import {Vertice, VerticeData, Transform} from './vertice.js';
+import {Vertice, VerticeConstructorOptions, Transform} from './vertice.js';
 
-export interface UniqueUrlData extends VerticeData {
+export interface UniqueUrlConstructorOptions extends VerticeConstructorOptions {
   url?: string | NormalizedUrl;
   source?: UrlSource;
   base?: string | URL;
@@ -54,7 +54,7 @@ export class UniqueUrl extends Vertice {
     return this.parsed !== undefined;
   }
 
-  constructor(data: UniqueUrlData = {}) {
+  constructor(data: UniqueUrlConstructorOptions = {}) {
     let {url, base, normalizer, referer, depth, ...dataForSuper} = data;
     super(dataForSuper);
 

--- a/src/model/vertices/vertice.ts
+++ b/src/model/vertices/vertice.ts
@@ -95,7 +95,7 @@ export abstract class Vertice {
       typeof data === 'string' ? ensureJsonMap(JSON.parse(data)) : data
     );
 
-    if (((has(object, '_id') || has(object, ['_collection', '_key'])))) {
+    if (has(object, ['_collection'])) {
       const ctor = Vertice.types.get(object._collection as string)?.constructor;
       if (ctor) {
         return plainToInstance(
@@ -106,7 +106,7 @@ export abstract class Vertice {
       }
     }
 
-    throw new TypeError('Vertices require collection and key or id');
+    throw new TypeError('Vertice data has no _collection property');
   }
 
   toJSON(): JsonMap {

--- a/src/services/arango-store.ts
+++ b/src/services/arango-store.ts
@@ -6,8 +6,9 @@ import {DocumentMetadata} from 'arangojs/documents.js';
 import {DocumentCollection} from 'arangojs/collection.js';
 import arrify from 'arrify';
 import slugify from '@sindresorhus/slugify';
-import {Vertice, Reference, VerticeData, isEdge, UniqueUrl, RespondsWith, Resource, LinksTo, IsChildOf, IsVariantOf, AppearsOn, DataSet, Fragment} from '../model/index.js';
+import {Vertice, Reference, isEdge, UniqueUrl, RespondsWith, Resource, LinksTo, IsChildOf, IsVariantOf, AppearsOn, DataSet, Fragment} from '../model/index.js';
 import { Project } from './project.js';
+import { JsonMap } from '@salesforce/ts-types'
 
 export {aql} from 'arangojs';
 
@@ -151,7 +152,7 @@ export class ArangoStore {
 
   async get<T extends Vertice = Vertice>(ref: Reference): Promise<T | undefined> {
     const [collection, key] = Vertice.idFromReference(ref).split('/');
-    return this.db.collection<VerticeData>(collection).document(key)
+    return this.db.collection<JsonMap>(collection).document(key)
       .then(json => Vertice.fromJSON(json) as T)
       .catch(() => undefined);
   }

--- a/src/services/graph-worker.ts
+++ b/src/services/graph-worker.ts
@@ -1,7 +1,7 @@
 import EventEmitter from 'node:events';
 import {AqlQuery} from 'arangojs/aql.js';
 import is from '@sindresorhus/is';
-import {JsonObject} from 'type-fest';
+import {JsonMap} from '@salesforce/ts-types';
 import {Project, Vertice, aql, ProjectConfig, ArangoStore, JobStatus} from '../index.js';
 
 export type GraphWorkerTask<T extends Vertice = Vertice> = (item: T) => Promise<void>;
@@ -62,7 +62,7 @@ export class GraphWorker<T extends Vertice = Vertice> extends EventEmitter {
         return item
       `;
 
-      return graph.query<JsonObject>(query, {count: true, batchSize: 10})
+      return graph.query<JsonMap>(query, {count: true, batchSize: 10})
         .then(async cursor => {
           this.status.total = cursor.count ?? 0;
           for await (const batch of cursor.batches) {

--- a/src/services/url-hierarchy-builder.ts
+++ b/src/services/url-hierarchy-builder.ts
@@ -3,7 +3,7 @@ import is from '@sindresorhus/is';
 import {GeneratedAqlQuery} from 'arangojs/aql';
 import {Vertice, Edge, UniqueUrl, IsChildOf, UrlSource, ArangoStore, aql} from '../index.js';
 import {ParsedUrl} from '@autogram/url-tools';
-import {JsonObject} from 'type-fest';
+import {JsonMap} from '@salesforce/ts-types';
 
 
 export interface HierarchyData<V extends Vertice = Vertice, E extends Edge = Edge> {
@@ -46,7 +46,7 @@ export class UrlHierarchyBuilder {
   // can be passed in, but should use the `aql` template literal
   // function rather than raw strings.
   async loadPool<V>(filter?: GeneratedAqlQuery): Promise<void> {
-    const cursor = await this.graph.query(
+    const cursor = await this.graph.query<JsonMap>(
       aql`
         FOR item in unique_urls
           FILTER item.parsed != null
@@ -54,7 +54,7 @@ export class UrlHierarchyBuilder {
           ${filter}
           return item`,
     );
-    await cursor.map(result => UniqueUrl.fromJSON(result as JsonObject))
+    await cursor.map(result => UniqueUrl.fromJSON(result))
       .then(urls => {
         this.pool = urls;
       })

--- a/src/tools/spreadsheet.ts
+++ b/src/tools/spreadsheet.ts
@@ -3,7 +3,7 @@ import * as fs from 'node:fs';
 import {Readable} from 'node:stream';
 import is from '@sindresorhus/is';
 import * as XLSX from 'xlsx';
-import {JsonPrimitive} from 'type-fest';
+import {JsonPrimitive} from '@salesforce/ts-types';
 import { Buffer } from 'node:buffer';
 
 XLSX.set_fs(fs);
@@ -24,10 +24,11 @@ XLSX.stream.set_readable(Readable);
  * Named columns: { col1: 'some data', col2: 123, ... }
  * Array of values: [ 'some data', 123 ]
  */
-export type SpreadsheetData = Record<string, SheetData> | SheetData[];
-export type SheetData = RowData[];
-export type RowData = Record<string, CellValue>;
-export type CellValue = JsonPrimitive;
+
+type Workbook = Sheet[] | Record<string, Sheet>;
+type Sheet = Row[];
+type Row = Record<string, Cell>;
+type Cell = JsonPrimitive
 
 type SpreadsheetWriteOptions = {
   format: XLSX.BookType;
@@ -41,7 +42,7 @@ export class Spreadsheet {
 
   workbook: XLSX.WorkBook;
 
-  constructor(data?: SpreadsheetData) {
+  constructor(data?: Workbook) {
     const {utils} = Spreadsheet;
     this.workbook = utils.book_new();
     if (!is.undefined(data)) {
@@ -57,7 +58,7 @@ export class Spreadsheet {
     }
   }
 
-  addSheet(data: SheetData, name?: string) {
+  addSheet(data: Sheet | Cell[], name?: string) {
     if (is.array(data)) {
       name = Spreadsheet.utils.book_append_sheet(this.workbook, XLSX.utils.json_to_sheet(data), name);
     }


### PR DESCRIPTION
Eliminates the `type-fest` dependency in favor of `@salesforce/ts-types`; the former covers far more ground with exotic type definitions than we need, and our primary use for it was the `JsonObject` collection of types. the Salesforce library covers the same with its `AnyJson` type, and also provides a collection of coercion and validation functions that eliminate quite a bit of parsed-json-validation boilerplate code.

This is related to #24; the full `@salesforce/kit` library may useful in the future, but for now we'll just adopt `ts-types.`