### PR TITLE
Tests

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,11 +2,13 @@
   "root": true,
   "parser": "@typescript-eslint/parser",
   "plugins": [
-    "@typescript-eslint"
+    "@typescript-eslint",
+    "ava"
   ],
   "extends": [
     "eslint:recommended",
     "plugin:@typescript-eslint/eslint-recommended",
-    "plugin:@typescript-eslint/recommended"
+    "plugin:@typescript-eslint/recommended",
+    "plugin:ava/recommended"
   ]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -25,12 +25,6 @@ coverage
 # nyc test coverage
 .nyc_output
 
-# Grunt intermediate storage (https://gruntjs.com/creating-plugins#storing-task-files)
-.grunt
-
-# Bower dependency directory (https://bower.io/)
-bower_components
-
 # node-waf configuration
 .lock-wscript
 
@@ -53,58 +47,15 @@ typings/
 # Optional eslint cache
 .eslintcache
 
-# Microbundle cache
-.rpt2_cache/
-.rts2_cache_cjs/
-.rts2_cache_es/
-.rts2_cache_umd/
-
 # Optional REPL history
 .node_repl_history
 
 # Output of 'npm pack'
 *.tgz
 
-# Yarn Integrity file
-.yarn-integrity
-
 # dotenv environment variables file
 .env
 .env.test
-
-# Unit test scratch DB
-test.db
-
-# parcel-bundler cache (https://parceljs.org/)
-.cache
-
-# Next.js build output
-.next
-
-# Nuxt.js build / generate output
-.nuxt
-dist
-
-# Gatsby files
-.cache/
-# Comment in the public line in if your project uses Gatsby and *not* Next.js
-# https://nextjs.org/blog/next-9-1#public-directory-support
-# public
-
-# vuepress build output
-.vuepress/dist
-
-# Serverless directories
-.serverless/
-
-# FuseBox cache
-.fusebox/
-
-# DynamoDB Local files
-.dynamodb/
-
-# TernJS port file
-.tern-port
 
 # MacOS cruft
 .DS_Store
@@ -112,7 +63,8 @@ dist
 # Gonna try to avoid this for now.
 package-lock.json
 
-# Default output for crawl data if nothing's passed in.
+# Build output, crawl data, instance-specific config files
 storage
 docs
 spidergram.json
+dist

--- a/ava.config.js
+++ b/ava.config.js
@@ -1,4 +1,9 @@
 export default {
+  "files": [
+    "tests/**/*",
+    "!tests/**/fixtures/*",
+    "!tests/**/*.md"
+  ],
   "extensions": {
     "ts": "module"
   },

--- a/ava.config.js
+++ b/ava.config.js
@@ -1,0 +1,13 @@
+export default {
+  "extensions": {
+    "ts": "module"
+  },
+  "concurrency": 1,
+  "failFast": true,
+  "environmentVariables": {
+    "NODE_NO_WARNINGS": "1"
+  },
+  "nodeArguments": [
+    "--loader=ts-node/esm"
+  ]
+};

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "build": "npm run clean; npm run compile",
     "compile": "tsc -p ./tsconfig.build.json",
     "docs": "rm -rf ./docs/*; typedoc src/index.ts --out ./docs",
-    "test": "ava"
+    "test": "ava",
+    "overage": "nyc --reporter=text ava"
   },
   "files": [
     "dist/**/*",
@@ -124,6 +125,7 @@
     "ava": "^5.1.0",
     "eslint": "^8.30.0",
     "eslint-plugin-ava": "^13.2.0",
+    "nyc": "^15.1.0",
     "oclif": "^3",
     "prettier": "^2.8.1",
     "shx": "^0.3.3",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "prepublish": "npm run build",
     "build": "npm run clean; npm run compile",
     "compile": "tsc -p ./tsconfig.build.json",
-    "docs": "rm -rf ./docs/*; typedoc src/index.ts --out ./docs"
+    "docs": "rm -rf ./docs/*; typedoc src/index.ts --out ./docs",
+    "test": "ava"
   },
   "files": [
     "dist/**/*",
@@ -104,6 +105,7 @@
     "vega-themes": "^2.12.0"
   },
   "devDependencies": {
+    "@ava/typescript": "^3.0.1",
     "@oclif/test": "^2.2.8",
     "@types/cheerio": "^0.22.31",
     "@types/cli-progress": "^3.11.0",
@@ -119,7 +121,9 @@
     "@types/uuid": "^8.3.4",
     "@typescript-eslint/eslint-plugin": "^5.47.0",
     "@typescript-eslint/parser": "^5.47.0",
+    "ava": "^5.1.0",
     "eslint": "^8.30.0",
+    "eslint-plugin-ava": "^13.2.0",
     "oclif": "^3",
     "prettier": "^2.8.1",
     "shx": "^0.3.3",

--- a/tests/project.test.ts
+++ b/tests/project.test.ts
@@ -1,0 +1,10 @@
+import test from 'ava';
+import { Project } from '../src/index.js';
+
+test('project config loads', async t => {
+	const p = await Project.config({ _configFilePath: 'spidegram.example.json' });
+  t.is(p.name, 'spidergram');
+  t.is(p.configuration._configFilePath, 'spidegram.example.json');
+  await t.notThrowsAsync(p.graph())
+});
+


### PR DESCRIPTION
Adding Ava test configuration back into the mix; we'd prefer Jest but it's currently a ball of snakes when it comes to ESM + Typescript. Ava has some rough edges, but works.

This adds:

* basic Ava configuration
* a /tests directory
* a simple test that verifies Project config works
* code coverage report via NYC
* npm `test` and `coverage` scripts
* tsconfig tweaks to ensure `src` and `dist` are explicit, while `tests` is ignored