### PR TITLE
Fix broken Report queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "vega-lite": "^5.6.0"
   },
   "devDependencies": {
+    "@ava/cooperate": "^1.0.0",
     "@ava/typescript": "^3.0.1",
     "@oclif/test": "^2.2.8",
     "@types/cheerio": "^0.22.31",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,12 @@
 export * from '@autogram/url-tools';
-export * as crawlee from 'crawlee';
-export * as arangojs from 'arangojs';
+export * as Typing from '@salesforce/ts-types';
+export * as Crawlee from 'crawlee';
+export * as Arango from 'arangojs';
+
 import lodash from 'lodash';
 export const _ = lodash;
 
 export * from './cli/index.js';
-
 export * from './model/index.js';
 export * from './services/index.js';
 export * from './spider/index.js';

--- a/tests/spreadsheet.test.ts
+++ b/tests/spreadsheet.test.ts
@@ -1,0 +1,52 @@
+import test from 'ava';
+import { Spreadsheet, Query, aql } from "../src/index.js";
+import * as fs from 'fs/promises';
+
+test('query results treated as sheet', async t => {
+  const data = await Query.run(aql`
+    FOR r IN resources
+    LIMIT 10
+    RETURN {
+      url: r.url,
+      status: r.code,
+      mime: r.mime
+    }
+  `);
+
+  const report = new Spreadsheet();
+  report.addSheet(data, 'report');
+  
+  await t.notThrowsAsync(
+    report.save('./tests/spreadsheet-simple')
+      .then(fileName => fs.stat(fileName)
+      .then(stats => stats ? fileName : false ))
+      .then(fileName => fileName ? fs.rm(fileName) : {} )
+  );
+})
+
+test('sheet structure respected', async t => {
+  const data = await Query.run(aql`
+    FOR r IN resources
+    LIMIT 10
+    RETURN {
+      url: r.url,
+      status: r.code,
+      mime: r.mime
+    }
+  `);
+
+  const report = new Spreadsheet();
+  report.addSheet({
+    name: 'Sheet 1',
+    data,
+    header: ['URL', 'HTTP Status', 'MIME Type']
+  });
+  
+  await t.notThrowsAsync(
+    report.save('./tests/spreadsheet-complex')
+      .then(fileName => fs.stat(fileName)
+      .then(stats => stats ? fileName : false ))
+      .then(fileName => fileName ? fs.rm(fileName) : {} )
+  );
+})
+


### PR DESCRIPTION
After recent improvements to the `Query` class, things got funky because the strongly typed input for `Spreadsheet.add()` wouldn't accept the default `AnyJson` output from `Query.run()`. It was a whole thing. This patch:

1. Updates the `Spreadsheet` class's constructor and supporting Types
2. Adds explicit type guards for incoming data
3. Standardizes the output functions as `toBuffer()` and `toStream()` for convenient piping
4. Adds a handful of automated tests for the Spreadsheet class