### PR TITLE
Data/Content extraction improvements

### DIFF
--- a/docs/STYLEGUIDE.md
+++ b/docs/STYLEGUIDE.md
@@ -2,7 +2,7 @@
 
 ## Helper Functions
 
-Spidergram includes quite a few standalone helper functions that can be used in multiple contexts; using them together effectively is easier when they follow similar standards and conventions.
+Spidergram includes quite a few utility functions that can be used in multiple contexts; using them together effectively is easier when they follow similar standards and conventions.
 
 ### Naming and organizing
 
@@ -13,8 +13,7 @@ Helper function names should be camel-cased and follow the pattern: Verb - Optio
 - `get` implies gathering gathering a known set of objects from a given context (e.g. `getPageData`, `getPlaintext`).
 - `fetch` implies retrieving the object from a remote location (e.g. `fetchPage`, `fetchResourcePayload`).
 
-Stateless helper functions large enough to be reused should live in their own files, along with any relevant type and interface definitions, TSDoc blocks, etc. File names should be kebab-cased versions of the helper function's name (e.g., `get-page-data.ts` would contain the function `getPageData()`).
-
+Stateless helper functions large enough to be reused should live in their own files, along with any relevant type and interface definitions, TSDoc blocks, etc. Slight variations and convenience wrappers/aliases (`findLinks` and `findWebLinks`, for example) can be placed the same file. File names should be kebab-cased versions of the primary helper function's name (e.g., `get-page-data.ts` would contain the function `getPageData()`).
 
 ### Handling flags and options
 
@@ -24,12 +23,13 @@ Stateless helper functions large enough to be reused should live in their own fi
 - Accept a customOptions param that defaults to {}
 - Use lodash to populate the defaults, and proceed.
 
-### Making return data explicit
+### Making complex return data explicit
 
-- define an export an interface, not a type, for the return value whenever possible
-- create a 'results' object at the top of the function, populated with any fallback values
-- include an optional 'success' flag, and leave it unset if something went wrong but no error was thrown. (Optional: Offering a 'silent' mode in the options that returns errors in the Response rather than throwing them.)
-- return the modified results object
+Functions that return primitives, existing object types, or arrays of existing object types, don't need to do anything special. If they build and return complex data structures, or have different execution paths that can result in different *types* of result data, being explicit is good.
+
+- Define an export an interface, not a type, for the return object whenever possible.
+- Create a 'results' object at the top of the function, populated with any fallback values.
+- Return the modified results object.
 
 ### Dealing with Async/Promises
 
@@ -38,39 +38,76 @@ TODO - mostly the same guidelines but with some notes around promise wrapping, t
 ``` typescript
 export interface MyFunctionResults {
   myData?: string,
-  success?: boolean,
-  errors?: Error[]
+  datums?: number
 }
 
 type Options = {
   flagOne?: boolean,
   flagTwo?: boolean,
-  silent?: boolean,
 }
 
 const defaults: Options {
   flagOne: false,
   flagTwo: true,
-  silent: false,
 }
 
 export function myFunction(param: string, customOptions: Options = {}) {
   const options = _.defaultsDeep(customOptions, defaults);
   const results: MyFunctionResults = {};
   
-  try {
-    if (options.flagOne) {
-      // Do stuff here
-      myData = 'We did things!';
-      results.success = true;
-    }
-  } catch(err: unknown) {
-    if (err instanceof Error) {
-      results.errors.push(err);
-    }
-    if (!silent) throw(err);
+  // Do stuff here…
+
+  if (options.flagOne) {
+    // Do other here…
   }
-  
+
+  if (options.flagTwo) {
+    // Do more things here…
+  }
+
+  return results;
+}
+```
+
+### Batch-processing functions
+
+If the helper function performs operations on a large input set, validating results and troubleshooting errors that only affect a hendful of the items can be frustrating. Whenever possible, use approaches that allow graceful recovery from errors by the calling function. Consider some of the following approaches:
+
+- If an explicit set of items will always be passed in, make it the function's first parameter.
+- If a set of items *or* criteria to assemble a set are both possible, move them both to the options object for clarity.
+- Use an optional 'silent' flag in the functions' options, and an 'errors' array in the results object.
+  - If the silent flag is set, accumulate errors in the array and return them alongside successful results rather than halting processing.
+  - Be sure each error message includes enough information to identify *which* record failed; 1000 'Could Not Save' messages are unhelpful.
+- Include summary statistics in the result object about how many items were examined, successfully processed, etc.
+- Don't use `console.log()` for status messages or updates; if ongoing status matters, consider making Worker object that emits status events, instead.
+
+``` typescript
+export interface BatchProcessorResults {
+  output: string[];
+  errors: Error[]
+}
+
+export interface BatchProcessorOptions {
+  silent?: boolean;
+}
+
+export const defaults: BatchProcessorOptions {
+  silent: false,
+}
+
+export function myBatchProcessor(input: string[], customOptions: Partial<BatchProcessorOptions> = {}) {
+  const options = _.defaultsDeep(customOptions, defaults);
+  const results: BatchProcessorResults = { output: [], errors: [] };
+
+  for (const value of input) {
+    try() {
+      // Do some stuff!
+      results.output.push(value);
+    } catch (err: unkonwn) {
+      if (silent && err instanceof Error) results.errors.push(err);
+      else throw new Error('WTF bro', e);
+    }
+  }
   return results;
 }
 ```

--- a/docs/STYLEGUIDE.md
+++ b/docs/STYLEGUIDE.md
@@ -4,6 +4,18 @@
 
 Spidergram includes quite a few standalone helper functions that can be used in multiple contexts; using them together effectively is easier when they follow similar standards and conventions.
 
+### Naming and organizing
+
+Helper function names should be camel-cased and follow the pattern: Verb - Optional Context - Object. Examples include `getPageData`, `parseMetaTags`, `findLinks`, and so on. Some verb examples:
+
+- `has` implies a predicate function that returns true if the object meets certain criteria, or contains certain information (e.g. `hasPlaintext`, `hasCategories`, `hasSubdomain`).
+- `find` implies searching for one or more objects that *might* be present in the context (e.g. `findLinks`, `findSitemapLinks`, `findPageParent`).
+- `get` implies gathering gathering a known set of objects from a given context (e.g. `getPageData`, `getPlaintext`).
+- `fetch` implies retrieving the object from a remote location (e.g. `fetchPage`, `fetchResourcePayload`).
+
+Stateless helper functions large enough to be reused should live in their own files, along with any relevant type and interface definitions, TSDoc blocks, etc. File names should be kebab-cased versions of the helper function's name (e.g., `get-page-data.ts` would contain the function `getPageData()`).
+
+
 ### Handling flags and options
 
 - Define but don't export an Options type, with all properties optional

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "@types/cheerio": "^0.22.31",
     "@types/cli-progress": "^3.11.0",
     "@types/content-type": "^1.1.5",
-    "@types/html-to-text": "^8.1.1",
+    "@types/html-to-text": "^9.0.0",
     "@types/inquirer": "^9.0.3",
     "@types/lodash": "^4.14.189",
     "@types/luxon": "^3.1.0",
@@ -138,7 +138,7 @@
     "cheerio": "^1.0.0-rc.12",
     "crawlee": "^3.1.0",
     "googleapis": "^108.0.1",
-    "html-to-text": "^8.2.1",
+    "html-to-text": "^9.0.0",
     "playwright": "^1.27.1",
     "readability-scores": "^1.0.8",
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.18.12/xlsx-0.18.12.tgz"

--- a/src/cli/commands/analyze.ts
+++ b/src/cli/commands/analyze.ts
@@ -44,17 +44,15 @@ export default class Analyze extends SgCommand {
         if (is.nonEmptyString(resource.body)) {
           let data: Record<string, unknown> = {};
           if (flags.metadata) {
-            data = HtmlTools.getPageData(resource.body);
+            data = HtmlTools.getPageData(resource);
           }
 
-          let text = '';
+          let text: string | undefined = '';
           if (flags.text || flags.readability) {
-            text = HtmlTools.getPlainText(resource.body, {
-              baseElements: { selectors: flags.body },
-            });
+            text = HtmlTools.getPageText(resource, flags.body);
           }
 
-          if (text.length > 0) {
+          if (text) {
             if (flags.text) {
               data.text = text
             }

--- a/src/cli/commands/analyze.ts
+++ b/src/cli/commands/analyze.ts
@@ -2,7 +2,6 @@ import is from '@sindresorhus/is';
 import {
   Resource,
   HtmlTools,
-  TextTools,
   GraphWorker,
   OutputLevel,
   aql
@@ -42,26 +41,20 @@ export default class Analyze extends SgCommand {
       filter: aql`FILTER item.code == 200 AND item.mime == 'text/html'`,
       task: async resource => {
         if (is.nonEmptyString(resource.body)) {
-          let data: Record<string, unknown> = {};
+
           if (flags.metadata) {
-            data = HtmlTools.getPageData(resource);
+            const data = HtmlTools.getPageData(resource);
+            if (data) resource.data = data;
           }
 
-          let text: string | undefined = '';
-          if (flags.text || flags.readability) {
-            text = HtmlTools.getPageText(resource, flags.body);
+          if (flags.text) {
+            const content = HtmlTools.getPageContent( resource, {
+              selectors: flags.body,
+              readability: flags.readability
+            });
+  
+            resource.content = content;
           }
-
-          if (text) {
-            if (flags.text) {
-              data.text = text
-            }
-            if (flags.readability) {
-              data.readability = TextTools.calculateReadability(text);
-            }
-          }
-
-          resource.data = data;
 
           await graph.push(resource);
         }

--- a/src/cli/commands/db/erase.ts
+++ b/src/cli/commands/db/erase.ts
@@ -1,6 +1,5 @@
 import { Flags } from '@oclif/core';
-import { CLI, SgCommand } from '../../index.js';
-
+import { CLI, TextTools, SgCommand } from '../../../index.js';
 export default class Erase extends SgCommand {
   static description = 'Discard stored crawling data';
 
@@ -37,7 +36,7 @@ export default class Erase extends SgCommand {
     const dbName = graph.db.name;
     let message = `Empty the collection${
       argv.length > 1 ? 's' : ''
-    } ${CLI.oxfordJoin(argv)} from ${dbName}?`;
+    } ${TextTools.joinOxford(argv)} from ${dbName}?`;
     if (flags.all) {
       message = `Empty ${CLI.chalk.bold.red('all data')} from ${dbName}?`;
     }

--- a/src/cli/shared/index.ts
+++ b/src/cli/shared/index.ts
@@ -2,4 +2,3 @@ export * from './flags.js';
 export * from './prompts.js';
 export * from './progress.js';
 export * from './format.js';
-export { oxfordJoin } from '../../tools/text.js';

--- a/src/multi.ts
+++ b/src/multi.ts
@@ -1,0 +1,19 @@
+import { Project, Resource, HtmlTools } from "./index.js";
+
+const matchedSelectors: HtmlTools.SelectorForResource[] = [
+  { test: r => r.parsed?.domain === 'schwab.com', selector: 'region-content > .region-content' },
+  { test: r => r.parsed?.domain === 'tdameritrade.com', selector: '.page-main-content' }
+]
+
+await getContent();
+
+async function getContent() {
+  const c = await Project.config();
+  const db = await c.graph();
+  const resource = await db.findById<Resource>('resources/ba439a21-ea10-5b2d-b842-6b9cfb9074cf');
+
+  if (resource && resource.body) {
+    resource.content = HtmlTools.getPageContent(resource, { matchedSelectors, readability: true })
+    await db.push(resource);
+  }
+}

--- a/src/single.ts
+++ b/src/single.ts
@@ -1,0 +1,25 @@
+import { Project, GraphWorker, Resource, HtmlTools, aql } from "./index.js";
+const config = await Project.config();
+const db = await config.graph();
+
+const matchedSelectors: HtmlTools.SelectorForResource[] = [
+  { test: r => r.parsed?.domain === 'schwab.com', selector: 'region-content > .region-content' },
+  { test: r => r.parsed?.domain === 'tdameritrade.com', selector: '.page-main-content' }
+]
+
+await getContent();
+
+async function getContent() {
+  await new GraphWorker<Resource>({
+    collection: 'resources',
+    filter: aql`FILTER item.code == 200 && item.mime == 'text/html'`,
+    task: async resource => {
+      if (resource.body) {
+        resource.content = HtmlTools.getPageContent(resource, { matchedSelectors, readability: true, defaultToFullDocument: false })
+      }
+      console.log(resource.url);
+      await db.push(resource);
+    }
+  }).run();
+  console.log('Done!');
+}

--- a/src/spider/handlers/sitemap-handler.ts
+++ b/src/spider/handlers/sitemap-handler.ts
@@ -36,7 +36,7 @@ export async function sitemapHandler(context: SpiderContext) {
   // Now parse the sitemap and pull out URLs. Some sites (vanityfair.com is one
   // example) do odd things like sitemap URLs with querystrings
 
-  const links = HtmlTools.findLinksInSitemap(xml.toString());
+  const links = HtmlTools.findSitempLinks(xml.toString());
 
   const subSitemaps = links.filter(l => l.label === 'sitemap');
   const normalLinks = links.filter(l => l.label !== 'sitemap');

--- a/src/tools/html/convert-html-to-text.ts
+++ b/src/tools/html/convert-html-to-text.ts
@@ -1,11 +1,10 @@
 import { htmlToText, HtmlToTextOptions } from 'html-to-text';
 import _ from 'lodash';
 
-export { HtmlToTextOptions } from 'html-to-text';
+export { HtmlToTextOptions as PlainTextOptions } from 'html-to-text';
 
 const defaults: HtmlToTextOptions = {
   wordwrap: false,
-  limits: { maxBaseElements: 1 },
   selectors: [{ selector: 'a', options: { ignoreHref: true } }],
 };
 
@@ -18,7 +17,7 @@ const defaults: HtmlToTextOptions = {
  * @param options.baseElements.selectors - An array of CSS selectors to identify the page's primary content.
  * @param options.limits.maxBaseElements - Increase to allow multiple primary content elements 
  */
-export function getPlainText(
+export function convertHtmlToText(
   html: string,
   options?: HtmlToTextOptions,
 ): string {

--- a/src/tools/html/find-links.ts
+++ b/src/tools/html/find-links.ts
@@ -53,7 +53,7 @@ export function findHeadLinks(input: string | cheerio.Root) {
  * Finds links (with titles and publication dates, if present) in Sitemap
  * and SitemapIndex XML markup.
  */
-export function findLinksInSitemap(input: string | cheerio.Root) {
+export function findSitempLinks(input: string | cheerio.Root) {
   const $ =
     typeof input === 'string'
       ? parseWithCheerio(input, { xmlMode: true })
@@ -87,7 +87,7 @@ export function findLinksInSitemap(input: string | cheerio.Root) {
  * Finds links (with titles and publication dates, if present) in RSS
  * and Atom feed markup.
  */
-export function findLinksInFeed(input: string | cheerio.Root) {
+export function findFeedLinks(input: string | cheerio.Root) {
   const $ =
     typeof input === 'string'
       ? parseWithCheerio(input, { xmlMode: true })
@@ -115,6 +115,8 @@ export function findLinksInFeed(input: string | cheerio.Root) {
 
   return results;
 }
+
+// TODO: Convert this code to use getElementData
 
 export function getLinkElementAttributes(
   element: cheerio.Element,

--- a/src/tools/html/get-page-content.ts
+++ b/src/tools/html/get-page-content.ts
@@ -1,0 +1,45 @@
+import { Resource } from '../../index.js';
+import { getPlainText, HtmlToTextOptions } from './get-plaintext.js';
+
+export type TestedSelector = [(r: Resource) => boolean, string | string[] | HtmlToTextOptions];
+export type PageTextOptions = string | string[] | TestedSelector[] | HtmlToTextOptions;
+
+export function getPageText(page: string | Resource, options: PageTextOptions = {}) {
+  const markup = (typeof page === 'string') ? page : page.body ?? '';
+  const resource = (page instanceof Resource) ? page : undefined;
+
+  if (typeof options === 'string' || isArrayOfStrings(options)) {
+    return getPlainText(markup, buildTransformOptions(options));
+  } if (isArrayOfTestedSelectors(options)) {
+    if (resource) {
+      const matchedSelector = options.find(tuple => tuple[0](resource))?.[1] ?? false;
+      if (matchedSelector) {
+        return getPlainText(markup, buildTransformOptions(matchedSelector));
+      }
+    } else {
+      throw new TypeError('TestedSelector requires Resource');
+    }
+  } else {
+    return getPlainText(markup, options);
+  }
+
+  return undefined;
+}
+
+function isArrayOfStrings(input: unknown): input is string[] {
+  return (Array.isArray(input) && (typeof input.pop() === 'string'));
+}
+
+function isArrayOfTestedSelectors(input: unknown): input is TestedSelector[] {
+  return (!isArrayOfStrings(input) && Array.isArray(input));
+}
+
+function buildTransformOptions(input: string | string[] | HtmlToTextOptions): HtmlToTextOptions {
+  if (typeof input === 'string') {
+    return { baseElements: { selectors: [input] }};
+  } else if (Array.isArray(input)) {
+    return { baseElements: { selectors: input }};
+  } else {
+    return input;
+  }
+}

--- a/src/tools/html/get-page-data.ts
+++ b/src/tools/html/get-page-data.ts
@@ -1,5 +1,6 @@
 import _ from "lodash";
 
+import { Resource } from "../../model/index.js";
 import { parseWithCheerio } from "./parse-with-cheerio.js";
 import { parseElementsToArray, parseElementsToDictionary } from './parse-elements.js';
 import { parseMetatags, MetaValues } from "./parse-meta.js";
@@ -95,8 +96,8 @@ export interface PageData {
   noscript?: Record<string, string | undefined>[],
 }
 
-export function getPageData(input: string | cheerio.Root, customOptions: PageDataOptions = {}): PageData {
-  const $ = typeof input === 'string' ? parseWithCheerio(input) : input;
+export function getPageData(input: string | cheerio.Root | Resource, customOptions: PageDataOptions = {}): PageData {
+  const $ = getCheerioFromInput(input);
   const results: PageData = { };
   const options = _.defaultsDeep(customOptions, defaultOptions);
   
@@ -179,4 +180,14 @@ export function getPageData(input: string | cheerio.Root, customOptions: PageDat
   }
 
   return results;
+}
+
+function getCheerioFromInput(input: string | cheerio.Root | Resource): cheerio.Root {
+  if (typeof input === 'string') {
+    return parseWithCheerio(input);
+  } else if (input instanceof Resource) {
+    return parseWithCheerio(input.body ?? '')
+  } else {
+    return input;
+  }
 }

--- a/src/tools/html/get-page-data.ts
+++ b/src/tools/html/get-page-data.ts
@@ -3,9 +3,8 @@ import _ from "lodash";
 import { Resource } from "../../model/index.js";
 import { parseWithCheerio } from "./parse-with-cheerio.js";
 import { parseElementsToArray, parseElementsToDictionary } from './parse-elements.js';
-import { parseMetatags, MetaValues } from "./parse-meta.js";
+import { parseMetaTags, MetaValues } from "./parse-meta-tags.js";
 import { getElementData, ElementData } from "./get-element-data.js";
-
 
 /**
  * Options to control extraction of structured data from HTML pages
@@ -64,7 +63,7 @@ type PageDataOptions = {
   metaArrayAttributes?: string[],
 }
 
-export const defaultOptions = {
+export const defaults = {
   attributes: true,
   head: true,
   meta: true,
@@ -99,7 +98,7 @@ export interface PageData {
 export function getPageData(input: string | cheerio.Root | Resource, customOptions: PageDataOptions = {}): PageData {
   const $ = getCheerioFromInput(input);
   const results: PageData = { };
-  const options = _.defaultsDeep(customOptions, defaultOptions);
+  const options = _.defaultsDeep(customOptions, defaults);
   
   if (options.attributes || options.all) {
     const attributes = getElementData($('body'));
@@ -128,7 +127,7 @@ export function getPageData(input: string | cheerio.Root | Resource, customOptio
   if (options.meta || options.all) {
     const headMeta = $('meta').toArray().map(element => $(element).attr());
     if (Object.entries(headMeta).length) {
-      results.meta = parseMetatags(headMeta);
+      results.meta = parseMetaTags(headMeta);
     }
   }
 

--- a/src/tools/html/get-page-text.ts
+++ b/src/tools/html/get-page-text.ts
@@ -1,0 +1,127 @@
+import { Resource } from '../../index.js';
+import { convertHtmlToText, PlainTextOptions } from './convert-html-to-text.js';
+import _ from 'lodash';
+
+
+/**
+ * Contains a predicate function and HTML-to-plaintext conversion options for
+ * Resources that match the predicate.
+ */
+export type SelectorForResource = {
+  /**
+   * A predicate function that accepts a {@link Resource} and returns a boolean.
+   */
+  test: (r: Resource) => boolean,
+
+
+  /**
+   * One or more CSS selectors used to find the page's primary content.
+   * 
+   * Alternatively, a complete {@link PlainTextOptions} object can be supplied,
+   * with full HTML-to-Text conversion options including DOM selectors.
+   */
+  selector: string | string[] | PlainTextOptions
+};
+
+/**
+ * Options to control the extraction of a page's primary content and its
+ * conversion to plaintext
+ */
+export interface PageTextOptions {
+  /**
+   * Raw HTML to be converted to plaintext; if the `resource` option is specified,
+   * this option is ignored.
+   */
+  markup?: string,
+
+  /**
+   * A {@link Resource | resource entity} whose body primary content should be
+   * converted to plaintext.
+   */
+  resource?: Resource;
+  
+  /**
+   * One or more CSS selectors used to find the page's primary content.
+   * 
+   * Alternatively, a complete {@link PlainTextOptions} object can be supplied,
+   * with full HTML-to-Text conversion options including DOM selectors.
+   */
+  selectors?: string | string[] | PlainTextOptions;
+  
+  /**
+   * An array of {@link SelectorForResource | predicate / selector pairs} that
+   * can be used to apply different selectors to different pages, depending on 
+   * the properties of the {@link Resource} object in question.
+   * 
+   * If this property is set, the `selectors` property is ignored. The order
+   * of the {@link SelectorForResource} objects matters, as the first one matched
+   * will be treated as the 'correct' selector.
+   */
+  matchedSelectors?: SelectorForResource[];
+  
+  /**
+   * Allow multiple page elements to be treated as the page's 'primary content'.
+   *
+   * @defaultValue `false`
+   */
+  allowMultipleContentElements?: boolean;
+  
+  /**
+   * Fall back to the full text of the page if the specified selectors have no
+   * matches. This will include headers, footers, navigation elements, etc.
+   *
+   * @defaultValue `false`
+   */
+  defaultToFullDocument?: boolean;
+}
+
+const defaults: PageTextOptions = {
+  allowMultipleContentElements: false,
+  defaultToFullDocument: true,
+}
+
+/**
+ * Convers a web page (in the form of raw HTML or a {@link Resource} object)
+ * into plain text.
+ */
+export function getPageText(input: PageTextOptions) {
+  const options: PageTextOptions = _.defaultsDeep(input, defaults);
+  const markup = options.markup ?? options.resource?.body ?? false;
+  const resource = options.resource;
+
+  if (!markup) {
+    throw new Error('No markup or resource supplied');
+  }
+
+  if (options.matchedSelectors) {
+    if (resource) {
+      const selector = options.matchedSelectors.find(match => match.test(resource))?.selector ?? false;
+      if (selector) {
+        return convertHtmlToText(markup, buildFullOptions(selector, options));
+      }
+    } else {
+      throw new Error('MatchedSelectors supplied without resource');
+    }
+  } else if (options.selectors) {
+    return convertHtmlToText(markup, buildFullOptions(options.selectors, options));
+  }
+
+  return convertHtmlToText(markup, buildFullOptions(undefined, options));
+}
+
+function buildFullOptions(input: string | string[] | PlainTextOptions | undefined, options: PageTextOptions): PlainTextOptions {
+  let output: PlainTextOptions = {};
+
+  if (typeof input === 'string') {
+    _.set(output, 'baseElements.selectors', [input]);
+  } else if (Array.isArray(input)) {
+    _.set(output, 'baseElements.selectors', input);
+  } else if (input !== undefined) {
+    output = input;
+  }
+
+  if (options.allowMultipleContentElements === false) _.set(output, 'limits.maxBaseElements', 1);
+  if (options.defaultToFullDocument === false) _.set(output, 'baseElements.returnDomByDefault', false)
+
+  return output;
+}

--- a/src/tools/html/get-plaintext.ts
+++ b/src/tools/html/get-plaintext.ts
@@ -3,7 +3,7 @@ import _ from 'lodash';
 
 export { HtmlToTextOptions } from 'html-to-text';
 
-const defaults = {
+const defaults: HtmlToTextOptions = {
   wordwrap: false,
   limits: { maxBaseElements: 1 },
   selectors: [{ selector: 'a', options: { ignoreHref: true } }],

--- a/src/tools/html/index.ts
+++ b/src/tools/html/index.ts
@@ -4,5 +4,6 @@ export * from './get-page-data.js';
 export * from './get-plaintext.js';
 export * from './parse-with-cheerio.js';
 export * from './find-patterns.js';
+export * from './get-page-content.js'
 
 export { social as getSocialLinks } from 'crawlee';

--- a/src/tools/html/index.ts
+++ b/src/tools/html/index.ts
@@ -1,9 +1,12 @@
-export * from './find-links.js';
-export * from './get-element-data.js';
+export * from './get-page-content.js';
 export * from './get-page-data.js';
-export * from './get-plaintext.js';
-export * from './parse-with-cheerio.js';
+export * from './get-page-text.js'
+
+export * from './get-element-data.js';
+export * from './find-links.js';
 export * from './find-patterns.js';
-export * from './get-page-content.js'
+
+export * from './convert-html-to-text.js';
+export * from './parse-with-cheerio.js';
 
 export { social as getSocialLinks } from 'crawlee';

--- a/src/tools/html/parse-meta-tags.ts
+++ b/src/tools/html/parse-meta-tags.ts
@@ -9,16 +9,16 @@ type Tag = Record<string, unknown> & {
   content?: string
 }
 
-type metaParseOptions = {
-  arrayMetaTags?: string[],
+type MetaTagOptions = {
+  arrayTags?: string[],
 }
 
-const defaultMetaParseOptions = {
-  arrayMetaTags: ['keywords', 'field_category'],
+const defaults: MetaTagOptions = {
+  arrayTags: ['keywords'],
 }
 
-export function parseMetatags(tags: Tag[], customOptions: metaParseOptions = {}): MetaValues {
-  const options = _.defaultsDeep(customOptions, defaultMetaParseOptions);
+export function parseMetaTags(tags: Tag[], customOptions: MetaTagOptions = {}): MetaValues {
+  const options = _.defaultsDeep(customOptions, defaults);
   const output: Record<string, string | string[]> = {};
 
   for (const tag of tags) {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,4 +1,4 @@
-export * as TextTools from './text.js';
+export * as TextTools from './text/index.js';
 export * as HtmlTools from './html/index.js';
 export * as GoogleTools from './google/index.js';
 export * as PageUtils from './page.js';

--- a/src/tools/text/get-readability-score.ts
+++ b/src/tools/text/get-readability-score.ts
@@ -1,0 +1,69 @@
+import readabilityScores from 'readability-scores';
+import _ from 'lodash';
+
+export interface ReadabilityScore extends Record<string, unknown> {
+	words?: number
+	sentences?: number
+  difficultWords?: string[];
+  score?: number;
+  formula?: string;
+}
+
+export interface ReadabilityScoreOptions {
+  stats?: boolean;
+  difficultWords?: boolean;
+  formula?: 'ARI' | 'DaleChall' | 'ColemanLiau' | 'FleschKincaid' | 'GunningFog' | 'SMOG' | 'Spache';
+}
+
+const defaults: Required<ReadabilityScoreOptions> = {
+  stats: true,
+  difficultWords: true,
+  formula: 'FleschKincaid'
+}
+
+export function getReadabilityScore(input: string, customOptions: ReadabilityScoreOptions = {}) {
+  const options: Required<ReadabilityScoreOptions> = _.defaultsDeep(customOptions, defaults);
+  const results: ReadabilityScore = { formula: options.formula };
+
+  const scoreConfig: Record<string, boolean> = {
+    difficultWords: options.difficultWords
+  };
+  scoreConfig[`${options.formula}`] = true;
+  const rawScores = readabilityScores(input, scoreConfig);
+  
+  switch (options.formula) {
+    case 'ARI':
+      results.score = rawScores.ari;
+      break;
+    case 'ColemanLiau':
+      results.score = rawScores.colemanLiau;
+      break;
+    case 'DaleChall':
+      results.score = rawScores.daleChall;
+      if (options.difficultWords) results.difficultWords = rawScores.daleChallDifficultWords;
+      break;
+    case 'FleschKincaid':
+      // We calculate the Reading Level rather than the Grade Level.
+      // See https://github.com/words/flesch for a standalone implementation.
+      results.score = 206.835 - 1.015 * (rawScores.wordCount / rawScores.sentenceCount) - 84.6 * (rawScores.syllableCount / rawScores.wordCount)
+      results.score = Number.parseFloat(results.score.toPrecision(1));
+      break;
+    case 'GunningFog':
+      results.score = rawScores.gunningFog;
+      break;
+    case 'SMOG':
+      results.score = rawScores.smog;
+      break;
+    case 'Spache':
+      results.score = rawScores.spache;
+      if (options.difficultWords) results.difficultWords = rawScores.spacheUniqueUnfamiliarWords;
+      break;
+  }
+
+  if (options.stats) {
+    results.words = rawScores.wordCount;
+    results.sentences = rawScores.sentenceCount;
+  }
+
+  return results;
+}

--- a/src/tools/text/get-readability-score.ts
+++ b/src/tools/text/get-readability-score.ts
@@ -46,7 +46,7 @@ export function getReadabilityScore(input: string, customOptions: ReadabilitySco
       // We calculate the Reading Level rather than the Grade Level.
       // See https://github.com/words/flesch for a standalone implementation.
       results.score = 206.835 - 1.015 * (rawScores.wordCount / rawScores.sentenceCount) - 84.6 * (rawScores.syllableCount / rawScores.wordCount)
-      results.score = Number.parseFloat(results.score.toPrecision(1));
+      results.score = Math.round((results.score * 100)) / 100;
       break;
     case 'GunningFog':
       results.score = rawScores.gunningFog;

--- a/src/tools/text/index.ts
+++ b/src/tools/text/index.ts
@@ -1,0 +1,2 @@
+export * from './get-readability-score.js';
+export * from './join-oxford.js';

--- a/src/tools/text/join-oxford.ts
+++ b/src/tools/text/join-oxford.ts
@@ -1,6 +1,4 @@
-import readabilityScores from 'readability-scores';
-
-export function oxfordJoin(input: string[], conjunction = 'and'): string {
+export function joinOxford(input: string[], conjunction = 'and'): string {
   if (input.length === 2) {
     return input.join(` ${conjunction} `);
   } else if (input.length > 2) {
@@ -12,5 +10,3 @@ export function oxfordJoin(input: string[], conjunction = 'and'): string {
     return input.join(', ');
   }
 }
-
-export const calculateReadability = readabilityScores;


### PR DESCRIPTION
This PR consolidates more of the data and content extraction tools:

- Wraps structured data parsing and "content" extraction in consistent helper functions (`getPageData()` and `getPageContent()` that operate on either markup strings or Resource objects.
- The `getPageContent()` options object controls the CSS selectors that identify a given page's "primary content," the HTML conversion rules themselves, and toggles features like content readability analysis.
- Although it's not enforced, the new "norm" in Spidergram code is that parsed and extracted structured data goes into `resource.data`, while processed content (plaintext, readability stats, etc) go into `resource.content`.

A significant development: When working with a large collection of Resources (say, bulk-processing, or running getPageContent() inside of a crawl's page handler) it *also* accept an array of "test/selector pairs" — the test is a predicate function that receives the current Resource, and the selector is a CSS selector or HTMLToTextOptions object that should be used _if the predicate matches_. The first matching selector is used, so order matters.

In the future, it might make sense to pull that test/match code out of `getPageContent` proper, and instead create a reusable wrapper function for page-based conditional execution of different filters and extractors. We'll see