### PR TITLE
Hierarchy tools

### DIFF
--- a/src/cli/commands/urls.ts
+++ b/src/cli/commands/urls.ts
@@ -89,7 +89,7 @@ export default class Urls extends SgCommand {
     subdomains: Flags.boolean({
       char: 'd',
       summary: 'Treat subdomains as children of their TLD',
-      default: true,
+      default: false,
     })
   };
 
@@ -128,12 +128,12 @@ export default class Urls extends SgCommand {
     }
     
     const summary: Record<string, number| string[]> = {
-      'Total URLs': rawUrls.length,
-      'Unique Hosts': flags.hosts ? [...hosts] : [...hosts].length,
-      'Hidden URLs': rawUrls.length - filteredUrls.length,
-      'Unparsable Urls': urls.unparsable.size,
-      'Non-Web URLs': urls.size - webUrls.length,
+      'Total URLs': rawUrls.length
     };
+    if (hosts.size > 1) summary['Unique Hosts'] = flags.hosts ? [...hosts] : [...hosts].length;
+    if (flags.hide) summary['Hidden URLs'] = rawUrls.length - filteredUrls.length;
+    if (urls.unparsable.size) summary['Unparsable Urls'] = urls.unparsable.size;
+    if (flags.nonweb) summary['Non-Web URLs'] = urls.size - webUrls.length;
 
     const output: string[] = [];
     if (flags.tree) {
@@ -158,10 +158,10 @@ export default class Urls extends SgCommand {
       };
 
       const hierarchy = new HierarchyTools.UrlHierarchyBuilder(treeOptions).add(webUrls);
-      summary['Orphaned URLs'] = hierarchy.items.filter(item => item.isOrphan).length;
-      const roots = hierarchy.findRoots();
+      const orphans = hierarchy.items.filter(item => item.isOrphan).length;
+      if (orphans) summary['Orphaned URLs'] = orphans;
 
-      for (const root of roots) {
+      for (const root of hierarchy.findRoots()) {
         output.push(root.render(renderOptions));
       }
     }

--- a/src/cli/commands/urls.ts
+++ b/src/cli/commands/urls.ts
@@ -69,7 +69,7 @@ export default class Urls extends SgCommand {
     preset: Flags.enum({
       summary: 'A URL display preset',
       default: 'default',
-      options: ['default', 'expand', 'collapse', 'plain']
+      options: ['default', 'expand', 'collapse', 'markdown']
     }),
     maxChildren: Flags.integer({
       char: 'm',
@@ -156,6 +156,15 @@ export default class Urls extends SgCommand {
           return item.name;
         }
       };
+
+      if (flags.preset === 'markdown') {
+        renderOptions.label = item => {
+          if (item instanceof HierarchyTools.UrlHierarchyItem) {
+            return `${item.isRoot ? '# ' : ''}[${item.name}](${item.data.url.toString()})`
+          }
+          return item.name;
+        };
+      }
 
       const hierarchy = new HierarchyTools.UrlHierarchyBuilder(treeOptions).add(webUrls);
       const orphans = hierarchy.items.filter(item => item.isOrphan).length;

--- a/src/cli/commands/urls.ts
+++ b/src/cli/commands/urls.ts
@@ -1,105 +1,177 @@
 import { Flags } from '@oclif/core';
-import { NormalizedUrl } from '@autogram/url-tools';
-import { CLI, SgCommand, aql } from '../../index.js';
+import { NormalizedUrlSet } from '@autogram/url-tools';
+import { CLI, Query, SgCommand, aql, HierarchyTools } from '../../index.js';
+import { URL_NO_COMMAS_REGEX, URL_WITH_COMMAS_REGEX } from 'crawlee';
+import { readFile } from 'fs/promises';
+import minimatch from 'minimatch';
 
 export default class Urls extends SgCommand {
-  static summary = 'Test URL normalization and filtering';
+  static summary = 'Summarize a list of URLs';
 
   static usage = '<%= config.bin %> <%= command.id %> [urls]';
 
   static examples = [
-    '<%= config.bin %> <%= command.id %> https://example.com',
-    '<%= config.bin %> <%= command.id %> --un --limit=100',
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> --input=urls.txt',
+    '<%= config.bin %> <%= command.id %> --preset=collapse',
+    "<%= config.bin %> <%= command.id %> --depth=5 --maxChildren=10 --highlight='**/*.pdf'",
   ];
 
   static flags = {
     ...CLI.globalFlags,
-    limit: Flags.integer({
-      summary: 'Limit the number of URLs tested',
-      default: 20,
+    input: Flags.string({
+      char: 'i',
+      summary: 'A database collection or filename.',
+      default: 'resources',
     }),
-    unfiltered: Flags.boolean({
-      summary: 'Show both changed and unchanged urls',
+    csv: Flags.boolean({
+      char: 'c',
+      summary: 'Treat input files as CSV',
       default: false,
     }),
+    summary: Flags.boolean({
+      char: 's',
+      summary: 'Display summary information about the full pool of URLs',
+      default: true,
+    }),
+    nonweb: Flags.boolean({
+      char: 'n',
+      summary: 'Include non-web URLs in the summary',
+      dependsOn: ['summary'],
+      default: false
+    }),
+    unparsable: Flags.boolean({
+      char: 'u',
+      summary: 'Include unparsable URLs in the summary',
+      dependsOn: ['summary'],
+      default: false
+    }),
+    hosts: Flags.boolean({
+      char: 'h',
+      summary: 'List the unique hostnames in the URL set',
+      dependsOn: ['summary'],
+      default: false
+    }),
+    hide: Flags.string({
+      summary: 'URLs matching this string will be hidden from view',
+      description: "Both --hide and --highlight use glob-style wildcards; '**/*cnn.com*' will match content on CNN or one of its domains; '**/news*' would only display the news directory and its descendents, and so on.",
+      required: false
+    }),
+    highlight: Flags.string({
+      summary: 'URLs matching this string will be highlighted',
+      required: false
+    }),
+    tree: Flags.boolean({
+      char: 't',
+      summary: 'Display a visual tree view of the parsable web URLs',
+      default: true,
+    }),
+    preset: Flags.enum({
+      summary: 'A URL display preset',
+      default: 'default',
+      options: ['default', 'expand', 'collapse', 'plain']
+    }),
+    maxChildren: Flags.integer({
+      char: 'm',
+      summary: "Truncate lists of children longer than this limit",
+      required: false,
+    }),
+    depth: Flags.integer({
+      summary: 'Summarize branches deeper than this level',
+      required: false,
+    }),
+    gaps: Flags.enum({
+      summary: 'Gap resolution strategy',
+      description: "How to deal with URL gaps, where a URL is implied by another URL's path but does not itself exist in the list of URLs. 'ignore' will discard URLs with gaps; 'adopt' will treat them as direct children of their closest ancestor, and 'bridge' will create intermediary URLs to accuratly represent the full path.",
+      options: ['ignore', 'adopt', 'bridge'],
+      default: 'bridge',
+    }),
+    subdomains: Flags.boolean({
+      char: 'd',
+      summary: 'Treat subdomains as children of their TLD',
+      default: true,
+    })
   };
 
-  static args = [
-    {
-      name: 'urls',
-      description: 'One or more URLs to crawl',
-      multiple: true,
-    },
-  ];
-
-  static strict = false;
-
   async run() {
+    const { flags } = await this.parse(Urls);
     const { graph } = await this.getProjectContext();
-    const { argv: urls, flags } = await this.parse(Urls);
 
-    const columns = {
-      original: { header: 'Original' },
-      normalized: { header: 'Normalized' },
-    };
+    let rawUrls: string[] = [];
+    let filteredUrls: string[] = [];
 
-    const data: { original: string; normalized: string }[] = [];
-    if (urls.length === 0) {
-      const query = aql`
-        FOR uu IN unique_urls
-        RETURN (uu.parsed.original == null) ? uu.url : uu.parsed.original
-      `;
-      const dbUrls = await graph
-        .query<string>(query)
-        .then(cursor => cursor.all());
-      urls.push(...dbUrls);
+    if (flags.input.indexOf('.') !== -1) {
+      const urlFile = await readFile(flags.input)
+        .then(buffer => buffer.toString())
+        .catch(() => this.error(`File ${flags.input} couldn't be opened`));
+      rawUrls = urlFile.match(flags.csv ? URL_NO_COMMAS_REGEX : URL_WITH_COMMAS_REGEX) || [];
+    } else {
+      const collection = graph.collection(flags.input);
+      if (await collection.exists() === false) {
+        this.error(`Collection ${flags.input} doesn't exist`);
+      }
+      rawUrls = await Query.run<string>(aql`FOR item IN ${collection} FILTER item.url != null RETURN item.url`);
     }
 
-    const results = {
-      total: urls.length,
-      altered: 0,
-      unparsable: 0,
+    if (rawUrls.length === 0) {
+      this.error('No URLs were found.');
+    }
+
+    filteredUrls = flags.hide ? rawUrls.filter(url => !minimatch(url, flags.hide ?? '')) : rawUrls;
+    const urls = new NormalizedUrlSet(filteredUrls, { strict: false });
+    
+    const webUrls = [...urls].filter(url => ['http:', 'https:'].includes(url.protocol));
+
+    const hosts = new Set<string>();
+    for (const url of webUrls) {
+      hosts.add(url.hostname);
+    }
+    
+    const summary: Record<string, number| string[]> = {
+      'Total URLs': rawUrls.length,
+      'Unique Hosts': flags.hosts ? [...hosts] : [...hosts].length,
+      'Hidden URLs': rawUrls.length - filteredUrls.length,
+      'Unparsable Urls': urls.unparsable.size,
+      'Non-Web URLs': urls.size - webUrls.length,
     };
 
-    for (const url of urls) {
-      try {
-        const normal = new NormalizedUrl(url).href;
-        if (normal === url) {
-          if (flags.unfiltered) {
-            data.push({
-              original: this.format.info(url),
-              normalized: this.format.info('unchanged'),
-            });
+    const output: string[] = [];
+    if (flags.tree) {
+      const treeOptions: HierarchyTools.UrlHierarchyBuilderOptions = { 
+        subdomains: flags.subdomains ? 'children' : undefined
+      };
+      if (flags.gaps === 'adopt') treeOptions.gaps = 'adopt';
+      if (flags.gaps === 'bridge') treeOptions.gaps = 'bridge';
+
+      const renderOptions: HierarchyTools.RenderOptions = {
+        preset: flags.preset,
+        maxChildren: flags.childern,
+        maxDepth: flags.depth,
+        label: (item) => {
+          if (item instanceof HierarchyTools.UrlHierarchyItem) {
+            if (flags.highlight && minimatch(item.data.url.toString(), flags.highlight)) return this.chalk.bold(item.name);
+            if (item.inferred) return this.chalk.dim(item.name); 
           }
-        } else {
-          results.altered++;
-          data.push({
-            original: url,
-            normalized: normal,
-          });
+          if (item.isRoot && flags.highlight === undefined) return this.chalk.bold(item.name);
+          return item.name;
         }
-      } catch {
-        results.unparsable++;
-        data.push({
-          original: url,
-          normalized: this.format.error('unparsable'),
-        });
+      };
+
+      const hierarchy = new HierarchyTools.UrlHierarchyBuilder(treeOptions).add(webUrls);
+      summary['Orphaned URLs'] = hierarchy.items.filter(item => item.isOrphan).length;
+      const roots = hierarchy.findRoots();
+
+      for (const root of roots) {
+        output.push(root.render(renderOptions));
       }
     }
 
-    this.ux.table(data.slice(0, flags.limit - 1), columns);
-    let message = `${this.format.success(
-      results.total,
-    )} URLs total (${this.format.success(
-      results.altered,
-    )} altered by normalizer`;
-    if (results.unparsable > 0) {
-      message += `, ${this.format.success(results.unparsable)} unparsable)`;
-    } else {
-      message += ')';
+    if (flags.summary) {
+      this.infoList(summary);
     }
-
-    this.log();
-    this.log(message);
+    if (flags.summary && flags.tree) this.log();
+    if (flags.tree) {
+      this.log(output.join('\n\n'));
+    }
   }
 }

--- a/src/cli/sg-command.ts
+++ b/src/cli/sg-command.ts
@@ -2,12 +2,20 @@ import { Project, ArangoStore, CLI, JobStatus } from '../index.js';
 import { CliUx, Command } from '@oclif/core';
 import { Duration } from 'luxon';
 import is from '@sindresorhus/is';
+import { joinOxford } from '../tools/text/join-oxford.js';
 
 export enum OutputLevel {
   silent = 0,
   interactive = 1,
   verbose = 2,
 }
+
+type InfoListOptions = {
+  title?: string,
+  align?: boolean,
+}
+
+type InfoListInput = Record<string, (number | string) | (number | string)[]>;
 
 /**
  * A base command that provided common functionality for all Spidergram commands.
@@ -32,6 +40,27 @@ export abstract class SgCommand extends Command {
   symbol = CLI.Prefixes;
   output = OutputLevel.interactive;
   progress = new CLI.progress.Bar({}, CLI.progress.Presets.shades_grey);
+
+  protected infoList(input: InfoListInput, customOptions: InfoListOptions = {}) {
+    const options = { align: true, ...customOptions };
+    const maxWidth = Object.keys(input).reduce((prev, current) => prev.length > current.length ? prev : current).length;
+    const lines: string[] = [];
+    
+    if (options.title) {
+      lines.push(this.chalk.bold(options.title));
+    }
+    
+    for (const [key, value] of Object.entries(input)) {
+      const title = this.chalk.bold(key);
+      const padding = options.align ? ' '.repeat(maxWidth - key.length) : '';
+      const values = Array.isArray(value) ? value : [value];
+      const content = joinOxford(values.map(v => typeof v === 'string' ? v : v.toLocaleString()));
+
+      lines.push(`${title}:${padding} ${content}`);
+    }
+
+    if (lines.length) this.ux.info(lines.join('\n'));
+  }
 
   protected get statics(): typeof SgCommand {
     return this.constructor as typeof SgCommand;

--- a/src/tools/hierarchy/hierarchy-builder.ts
+++ b/src/tools/hierarchy/hierarchy-builder.ts
@@ -89,14 +89,15 @@ export abstract class HierarchyBuilder<
    * The root node with the largest number of descendants, if one exists.
    */
   findLargestRoot(): ItemType | undefined {
-    return this.findRoots()
-      .sort((a, b) => a.descendents.length - b.descendents.length)[0];
+    return this.findRoots()[0];
   }
 
   /**
    * An array of all root nodes in the Hierarchy pool
    */
   findRoots(): ItemType[] {
-    return this.items.filter(item => item.isRoot);
+    return this.items.filter(item => item.isRoot)
+      .sort((a, b) => a.descendants.length - b.descendants.length)
+      .reverse();
   }
 }

--- a/src/tools/hierarchy/hierarchy-builder.ts
+++ b/src/tools/hierarchy/hierarchy-builder.ts
@@ -14,10 +14,14 @@ export abstract class HierarchyBuilder<
   UserData = Record<string, unknown>,
   InputType = UserData
 > {
-  _items: Map<string, ItemType>;
+  /**
+   * An ID-keyed map of all items in the hierarchy, including root nodes, orphans,
+   * leaf nodes, and so on.
+   */
+  readonly pool: Map<string, ItemType>;
   
   constructor() {
-    this._items = new Map<string, ItemType>();
+    this.pool = new Map<string, ItemType>();
   }
   
   /**
@@ -28,9 +32,8 @@ export abstract class HierarchyBuilder<
    * InputType is specified, however, this function is reponsible for transforming it
    * into the UserData required by the HierarchyItem class before creating the instance.
    */
-  abstract makeItem(input: InputType): ItemType;
+  abstract makeItem(input?: InputType | UserData): ItemType;
   
-
   /**
    * HierarchyBuilder implementations use this function to iterate though the full list
    * of items and populate their parent/child relationships.
@@ -42,7 +45,7 @@ export abstract class HierarchyBuilder<
    * leaf nodes, and so on.
    */
   get items() {
-    return [...this._items.values()];
+    return [...this.pool.values()];
   }
 
   /**
@@ -52,11 +55,11 @@ export abstract class HierarchyBuilder<
    * @param input - One or more data objects to be turned into HierarchyItems
    * @param populateRelationships - Set to `false` to suppress recalculating relationships
    */
-  add(input: InputType | InputType[], populateRelationships = true): this {
+  add(input: (InputType | UserData) | (InputType | UserData)[], populateRelationships = true): this {
     const inputs = Array.isArray(input) ? input : [input];
     for (const i of inputs) {
       const item = this.makeItem(i);
-      this._items.set(item.id, item);
+      this.pool.set(item.id, item);
     }
     if (populateRelationships) this.populateRelationships();
     return this;
@@ -78,7 +81,7 @@ export abstract class HierarchyBuilder<
       for (const child of item.children) {
         child.setParent(undefined)
       }
-      this._items.delete(item.id);
+      this.pool.delete(item.id);
     }
 
     if (populateRelationships) this.populateRelationships();

--- a/src/tools/hierarchy/hierarchy-item.ts
+++ b/src/tools/hierarchy/hierarchy-item.ts
@@ -98,7 +98,7 @@ export class HierarchyItem<UserData = Record<string, unknown>> {
 
     // No ancestors as children
     if (this.ancestors.map(ancestor => ancestor.id).includes(newChild.id)) {
-      throw new Error('Item cannot have an ancestor as a descendent');
+      throw new Error('Item cannot have an ancestor as a descendant');
     }
 
     // If the item is already a child, return.
@@ -131,17 +131,17 @@ export class HierarchyItem<UserData = Record<string, unknown>> {
   }
   
   /**
-   * An array of nodes containing the current item and all of its descendents
+   * An array of nodes containing the current item and all of its descendants
    */
   get flattened(): this[] {
-    return [this, ...this.descendents];
+    return [this, ...this.descendants];
   }
 
   /**
-   * An array of nodes containing all of the current item's descendents
+   * An array of nodes containing all of the current item's descendants
    */
-  get descendents(): this[] {
-    return _.flattenDeep([this.children, ...this.children.map(child => child.descendents)]);
+  get descendants(): this[] {
+    return _.flattenDeep([this.children, ...this.children.map(child => child.descendants)]);
   }
 
   /**
@@ -171,19 +171,7 @@ export class HierarchyItem<UserData = Record<string, unknown>> {
   /**
    * A Leaf node has a parent, but no children.
    */
-  get isLeaf() {
-    return (this.parent && this.children.length === 0);
-  }
-
-
-  /**
-   * Builds a simple string representation of the node and all of its children. 
-   */
-  toTreeString(indent = 0) {
-    let output = '  '.repeat(indent) + this.name + `\n`;
-    for (const child of this.children) {
-      output += child.toTreeString(indent + 1);
-    }
-    return output;
+  get isLeaf(): boolean {
+    return (this.parent !== undefined && this.children.length === 0);
   }
 }

--- a/src/tools/hierarchy/hierarchy-item.ts
+++ b/src/tools/hierarchy/hierarchy-item.ts
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+import { render, RenderOptions } from './render.js';
 
 /**
  * An individual node in a hierarchy, responsible for its own identity and
@@ -6,7 +7,7 @@ import _ from 'lodash';
  * 
  * @typeParam UserData - Payload data for the hierarchy item
  */
-export class HierarchyItem<UserData = Record<string, unknown>> {
+export class HierarchyItem<UserData extends Record<string, unknown> = Record<string, unknown>> {
   protected static _idCounter = 0;
   protected _name?: string;
   protected _hierarchyId = HierarchyItem._idCounter++;
@@ -173,5 +174,9 @@ export class HierarchyItem<UserData = Record<string, unknown>> {
    */
   get isLeaf(): boolean {
     return (this.parent !== undefined && this.children.length === 0);
+  }
+
+  render(options: string | RenderOptions = {}): string {
+    return render(this, options);
   }
 }

--- a/src/tools/hierarchy/hierarchy-item.ts
+++ b/src/tools/hierarchy/hierarchy-item.ts
@@ -1,13 +1,15 @@
 import _ from 'lodash';
 import { render, RenderOptions } from './render.js';
 
+type UserDataDefault = Record<string, unknown>
+
 /**
  * An individual node in a hierarchy, responsible for its own identity and
  * parent/child relationships.
  * 
  * @typeParam UserData - Payload data for the hierarchy item
  */
-export class HierarchyItem<UserData extends Record<string, unknown> = Record<string, unknown>> {
+export class HierarchyItem<UserData extends UserDataDefault = UserDataDefault> {
   protected static _idCounter = 0;
   protected _name?: string;
   protected _hierarchyId = HierarchyItem._idCounter++;
@@ -26,7 +28,7 @@ export class HierarchyItem<UserData extends Record<string, unknown> = Record<str
   /**
    * Create a new hierarchy item with the passed-in data, but no parents or children 
    */
-  constructor(public data: UserData) {
+  constructor(public data?: UserData) {
     this.children = [];
   }
   
@@ -57,7 +59,7 @@ export class HierarchyItem<UserData extends Record<string, unknown> = Record<str
   }
 
   /**
-   * A descriptive label for the node; if none exists, falls back to the ID.
+   * A descriptive label for the node; if none exists, fall back to the ID.
    */
   get name(): string {
     return this._name ?? this.id;
@@ -66,7 +68,6 @@ export class HierarchyItem<UserData extends Record<string, unknown> = Record<str
   set name(input: string) {
     this._name = input;
   }
-
 
   /**
    * Set or remove the item's parent, removing it from the previous parent's children
@@ -154,7 +155,6 @@ export class HierarchyItem<UserData extends Record<string, unknown> = Record<str
     return [...this.parent.children].filter(item => item.id !== this.id);
   }
 
-
   /**
    * A Root node has children but no parent.
    */
@@ -176,7 +176,7 @@ export class HierarchyItem<UserData extends Record<string, unknown> = Record<str
     return (this.parent !== undefined && this.children.length === 0);
   }
 
-  render(options: string | RenderOptions = {}): string {
+  render(options: RenderOptions<HierarchyItem> = {}): string {
     return render(this, options);
   }
 }

--- a/src/tools/hierarchy/index.ts
+++ b/src/tools/hierarchy/index.ts
@@ -1,6 +1,7 @@
 export * from './hierarchy-builder.js';
 export * from './hierarchy-item.js';
 export * from './url-hierarchy-builder.js';
+export * from './render.js';
 
 /**
  * Tools for building and working with parent/child hierarchies

--- a/src/tools/hierarchy/render.ts
+++ b/src/tools/hierarchy/render.ts
@@ -1,0 +1,93 @@
+import { HierarchyItem } from './index.js';
+import _ from 'lodash';
+
+/**
+ * Options to control how trees are rendered to text
+ */
+export interface RenderOptions {
+  /**
+   * Maximum tree depth to display
+   *  
+   * @defaultValue `Infinity`
+   */
+  maxDepth?: number,
+
+  /**
+   * Maximum number of children to display for each item
+   *  
+   * @defaultValue `Infinity`
+   */
+  maxChildren?: number,
+
+  /**
+   * Optional predicate function to filter hierarchy items before they're displayed.
+   */
+  filter?: (item: HierarchyItem) => boolean,
+
+  /**
+   * Optional formatting function to control how the name of a hierarchy item is
+   * displayed in the tree; defaults to the item's ID property.
+   */
+  name?: (item: HierarchyItem) => string,
+
+  prefix?: string,
+}
+
+const presets: Record<string, RenderOptions> = {
+  default: {}
+};
+
+const defaults: RenderOptions = {
+  maxDepth: 1,
+  maxChildren: 20,
+  prefix: '  ',
+};
+
+type RenderPreset = Extract<keyof typeof presets, string>
+
+export function render(item: HierarchyItem, customOptions: RenderPreset | RenderOptions = 'default'): string {
+  let options: RenderOptions = {};
+  if (typeof customOptions === 'string') {
+    options = _.defaultsDeep(presets[customOptions], defaults);
+  } else {
+    options = _.defaultsDeep(customOptions, defaults);
+  }
+  return formatItem(item, options);
+}
+
+function formatItem(item: HierarchyItem, options: RenderOptions, depth = 0): string {
+  const maxDepth = options.maxDepth ?? Infinity;
+  const maxChildren = options.maxChildren ?? Infinity;
+
+  if (item.children.length === 0) return format(item, options, depth);
+  if (depth >= maxDepth) {
+    return `${format(item, options, depth)} (${item.descendants.length} descendants)`;
+  }
+
+  const children = item.children.sort((a, b) => a.name.localeCompare(b.name));
+
+  const lines: string[] = [];
+  const displayChildren = children.slice(0, maxChildren - 1);
+  const summarizedChildren = children.slice(maxChildren - 1, -1);
+
+  lines.push(format(item, options, depth));
+  for (const child of displayChildren) {
+    lines.push(formatItem(child, options, depth + 1));
+  }
+  if (summarizedChildren.length > 0) {
+    const descendants = summarizedChildren.map(item => item.descendants).flat().length;
+    let summary = prefix(options, depth + 1);
+    summary += `…${summarizedChildren.length} additional children`;
+    if (descendants > 0) summary += `, with ${descendants} descendants`;
+    lines.push(summary);
+  }
+  return lines.join(`\n`);
+}
+
+function format(item: HierarchyItem, options: RenderOptions, depth = 0): string {
+  return prefix(options, depth) + (options.name ? options.name(item) : item.name);
+}
+
+function prefix(options: RenderOptions, depth = 0) {
+  return (options.prefix ?? '  ').repeat(depth);
+}

--- a/src/tools/hierarchy/render.ts
+++ b/src/tools/hierarchy/render.ts
@@ -13,7 +13,7 @@ export interface RenderOptions<T extends HierarchyItem = HierarchyItem> {
    * - default: Only display the first 10 items from each directory; summarize the rest.
    * - expand: Display the full tree, sorted alphabetically, with no limits
    * - collapse: Hide and summarize leaf nodes, displaying only branches
-   * - plain: Expand and display all items with minimal formatting; indent using tabs rather than ASCII tree art.
+   * - markdown: Expand and display all items with minimal formatting; indent using markdown list syntax.
    *
    * Additional option flags and values will override the preset defaults.
    * 
@@ -65,6 +65,7 @@ export interface RenderOptions<T extends HierarchyItem = HierarchyItem> {
 
   characters?: {
     root: string,
+    spacer: string,
     parent: string,
     item: string;
     itemLast: string,
@@ -74,6 +75,7 @@ export interface RenderOptions<T extends HierarchyItem = HierarchyItem> {
 
 const defaultChars = {
   root:       '',
+  spacer:     '',
   parent:     ' │  ',
   item:       ' ├─ ',
   itemLast:   ' ╰─ ',
@@ -123,15 +125,17 @@ const presets: Record<string, RenderOptions<HierarchyItem>> = {
     collapse: () => false,
     visibleChildren: item => item.children.filter(child => !child.isLeaf)
   },
-  plain: {
+  markdown: {
     collapse: () => false,
     visibleChildren: item => item.children,
+    label: item => item.isRoot ? `# ${item.name}` : item.name,
     characters: {
       root:       '',
-      parent:     '\t',
-      item:       '\t',
-      itemLast:   '\t',
-      parentLast: '\t',    
+      spacer:     '- ',
+      parent:     '  ',
+      item:       '  ',
+      itemLast:   '  ',
+      parentLast: '  ',    
     }
   }
 };
@@ -194,7 +198,7 @@ function getChildren<T extends HierarchyItem>(item: T, options: RenderOptions<T>
 let prefixes: string[] = [];
 
 function prefix<T extends HierarchyItem>(depth = 0, last = false, options: RenderOptions<T>) {
-  const { root, parent, item, itemLast, parentLast } = options.characters ?? defaultChars;
+  const { root, spacer, parent, item, itemLast, parentLast } = options.characters ?? defaultChars;
 
   if (depth === 0) {
     prefixes = [];
@@ -218,7 +222,7 @@ function prefix<T extends HierarchyItem>(depth = 0, last = false, options: Rende
     prefixes[prefixes.length - 1] = currentPrefix;
   }
 
-  return prefixes.join('');
+  return [...prefixes, spacer].join('');
 }
 
 function pluralize(input: number | unknown[], singular: string, plural: string) {

--- a/src/tools/hierarchy/render.ts
+++ b/src/tools/hierarchy/render.ts
@@ -38,8 +38,8 @@ const presets: Record<string, RenderOptions> = {
 };
 
 const defaults: RenderOptions = {
-  maxDepth: 1,
-  maxChildren: 20,
+  maxDepth: Infinity,
+  maxChildren: Infinity,
   prefix: '  ',
 };
 

--- a/src/tools/hierarchy/render.ts
+++ b/src/tools/hierarchy/render.ts
@@ -5,6 +5,20 @@ import _ from 'lodash';
  * Options to control how trees are rendered to text
  */
 export interface RenderOptions<T extends HierarchyItem = HierarchyItem> {
+  [key: string]: unknown;
+
+  /**
+   * The name of a rendering preset to use; built-in options include:
+   * 
+   * - default: Render the full tree, sorted alphabetically, with no limits
+   * - branches: Hide and summarize leaf nodes, rendering only branches
+   * - plain: Expand and display all options with minimal formatting;
+   *     indent using tabs rather than ASCII tree art.
+   *
+   * Additional option flags and values will override the preset defaults.
+   * 
+   * @type {?Extract<keyof typeof presets, string>}
+   */
   preset?: Extract<keyof typeof presets, string>;
 
   /**
@@ -101,7 +115,7 @@ const presets: Record<string, RenderOptions<HierarchyItem>> = {
     collapse: () => false,
     children: item => item.children.filter(child => !child.isLeaf)
   },
-  tsv: {
+  plain: {
     collapse: () => false,
     children: item => item.children,
     characters: {
@@ -117,12 +131,8 @@ const presets: Record<string, RenderOptions<HierarchyItem>> = {
 const defaults: RenderOptions<HierarchyItem> = presets.default;
 
 export function render<T extends HierarchyItem>(item: T, customOptions: RenderOptions<T> = { }): string {
-  let options: RenderOptions<T> = {};
-  if (typeof customOptions === 'string') {
-    options = _.defaultsDeep(presets[customOptions], defaults);
-  } else {
-    options = _.defaultsDeep(customOptions, defaults);
-  }
+  const preset = customOptions.preset ? presets[customOptions.preset] ?? {} : {};
+  const options: RenderOptions<T> = _.defaultsDeep(customOptions, preset, defaults);
   return renderItem(item, options);
 }
 

--- a/src/tools/hierarchy/url-hierarchy-builder.ts
+++ b/src/tools/hierarchy/url-hierarchy-builder.ts
@@ -6,13 +6,11 @@ import { NormalizedUrl, ParsedUrl } from '@autogram/url-tools';
 type ObjectWithUrl = Record<string, unknown> & { url: string | ParsedUrl };
 type UrlInput = string | URL | ObjectWithUrl;
 
-class UrlHierarchyItem extends HierarchyItem<ObjectWithUrl> {
+export class UrlHierarchyItem extends HierarchyItem<ObjectWithUrl> {
   inferred = false;
   adopted = false;
   get name(): string {
-    let name = this._name ?? this.id.split('/').pop() ?? this.hierarchyId.toString();
-    if (this.inferred) name += ` (inferred)`;
-    return name;
+    return this._name ?? this.id.split('/').pop() ?? this.hierarchyId.toString();
   }
 }
 

--- a/src/tools/hierarchy/url-hierarchy-builder.ts
+++ b/src/tools/hierarchy/url-hierarchy-builder.ts
@@ -13,6 +13,10 @@ export class UrlHierarchyItem extends HierarchyItem<ObjectWithUrl> {
   get name(): string {
     return this._name ?? this.id.split('/').pop() ?? this.hierarchyId.toString();
   }
+  set name(input: string) {
+    this._name = input;
+  }
+
 
   constructor(public data: ObjectWithUrl) {
     super(data);
@@ -76,10 +80,10 @@ export interface UrlHierarchyBuilderOptions {
 }
 
 const defaults: UrlHierarchyBuilderOptions = {
-  subdomains: 'ignore',
   ignoreSearch: false,
   ignoreHash: true,
-  gaps: 'adopt'
+  gaps: 'adopt',
+  subdomains: 'ignore',
 }
 
 /**
@@ -139,6 +143,7 @@ export class UrlHierarchyBuilder<UserData extends ObjectWithUrl = ObjectWithUrl>
     const id = 'root:' + rootName;
     const root = new UrlHierarchyItem({ url: id });
     root.id = id;
+    root.name = rootName;
     root.inferred = true;
     this.pool.set(id, root);
     for(const child of children) {

--- a/src/tools/hierarchy/url-hierarchy-builder.ts
+++ b/src/tools/hierarchy/url-hierarchy-builder.ts
@@ -17,7 +17,6 @@ export class UrlHierarchyItem extends HierarchyItem<ObjectWithUrl> {
     this._name = input;
   }
 
-
   constructor(public data: ObjectWithUrl) {
     super(data);
   }

--- a/tests/url-hierarchy.test.ts
+++ b/tests/url-hierarchy.test.ts
@@ -7,14 +7,15 @@ test('example hierarchy parsed', t => {
   const urls = JSON.parse(buffer.toString()) as string[];
   
   const options: HierarchyTools.UrlHierarchyBuilderOptions = {
-    gaps: 'fill',
+    gaps: 'adopt',
     subdomains: 'children',
   }
+  
   const uhb = new HierarchyTools.UrlHierarchyBuilder(options).add(urls);
 
   t.assert(uhb.findRoots().length === 1);
   
-  const root = uhb.findRoot();
+  const root = uhb.findLargestRoot();
   t.assert(root !== undefined);
   t.assert(uhb.items.filter(item => item.gap !== 'filled').length === urls.length);
 });

--- a/tests/url-hierarchy.test.ts
+++ b/tests/url-hierarchy.test.ts
@@ -7,15 +7,12 @@ test('example hierarchy parsed', t => {
   const urls = JSON.parse(buffer.toString()) as string[];
   
   const options: HierarchyTools.UrlHierarchyBuilderOptions = {
-    gaps: 'adopt',
+    gaps: 'bridge',
     subdomains: 'children',
   }
   
   const uhb = new HierarchyTools.UrlHierarchyBuilder(options).add(urls);
 
   t.assert(uhb.findRoots().length === 1);
-  
-  const root = uhb.findLargestRoot();
-  t.assert(root !== undefined);
-  t.assert(uhb.items.filter(item => item.gap !== 'filled').length === urls.length);
+  t.assert(uhb.items.filter(item => !item.inferred).length === urls.length);
 });

--- a/tests/url-hierarchy.test.ts
+++ b/tests/url-hierarchy.test.ts
@@ -1,8 +1,8 @@
 import test from 'ava';
 import { readFileSync } from 'fs';
-import { HierarchyTools } from '../src/index.js';
+import { HierarchyTools, UniqueUrl, NormalizedUrl } from '../src/index.js';
 
-test('example hierarchy parsed', t => {
+test('parses hierarchy', t => {
   const buffer = readFileSync('./tests/fixtures/urls/ethanmarcotte.json')
   const urls = JSON.parse(buffer.toString()) as string[];
   
@@ -15,4 +15,12 @@ test('example hierarchy parsed', t => {
 
   t.assert(uhb.findRoots().length === 1);
   t.assert(uhb.items.filter(item => !item.inferred).length === urls.length);
+});
+
+test('handles graph objects', t => {
+  const uu = new UniqueUrl({ url: 'https://example.com' });
+  const uhb = new HierarchyTools.UrlHierarchyBuilder<UniqueUrl>().add([uu]);
+  const uhi = [...uhb.items][0];
+
+  t.assert(uhi.data.parsed instanceof NormalizedUrl);
 });


### PR DESCRIPTION
This final patch brings more testing with a variety of URL trees, more flexible rendering options, less reliance on weird generics, and a CLI update that supports quick and easy summaries of already-crawled URLs _or_ arbitrary URL lists from a file.

There are also four URL Hierarchy display presets:
- `default` shows a somewhat truncated view with up to 10 urls per directory, and a summary of how many have been hidden.
- `expand` opens up the tree and shows absolutely everything; this can be EXTREMELY long with large sites, obviously.
- `collapse` shows _only_ branches, summarizing how many leaves were hidden. It's useful for getting a quick overview of a large site.
- `markdown` formats the tree as a bulleted markdown list, with link formatting for each item.