### PR TITLE
Fix download handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "@salesforce/ts-types": "^1.7.1",
     "@sindresorhus/is": "^5.3.0",
     "@sindresorhus/slugify": "^2.1.1",
+    "@types/fs-extra": "^11.0.1",
     "@types/set-cookie-parser": "^2.4.2",
     "@vladfrangu/async_event_emitter": "^2.1.2",
     "aql-builder": "^0.5.0",

--- a/src/spider/handlers/download-handler.ts
+++ b/src/spider/handlers/download-handler.ts
@@ -1,6 +1,8 @@
 import { Readable } from 'node:stream';
 import { fileNameFromHeaders } from '../helpers/mime.js';
 import { SpiderContext } from '../context.js';
+import { Project } from '../../index.js';
+import { ensureDir } from "fs-extra";
 
 export async function downloadHandler(context: SpiderContext): Promise<void> {
   const { graph, files, saveResource, sendRequest } = context;
@@ -18,7 +20,11 @@ export async function downloadHandler(context: SpiderContext): Promise<void> {
     resource.key +
     '-' +
     fileNameFromHeaders(new URL(buffer.url), buffer.headers);
-  await files('downloads').writeStream(fileName, Readable.from(buffer.rawBody));
+
+  const directory = [resource.parsed.hostname.replaceAll('.', '-'), resource.mime?.replaceAll('/', '-') ?? 'unknown'].join('/')
+  const proj = await Project.config();
+  await ensureDir([proj.root ?? '.', 'storage', 'downloads', directory].join('/'));
+  await files('downloads').writeStream([directory, fileName].join('/'), Readable.from(buffer.rawBody));
 
   resource.payload = { bucket: 'downloads', path: fileName };
   await graph.push(resource);

--- a/src/spider/handlers/download-handler.ts
+++ b/src/spider/handlers/download-handler.ts
@@ -1,31 +1,34 @@
-import { Readable } from 'node:stream';
+import { Duplex } from 'node:stream';
 import { fileNameFromHeaders } from '../helpers/mime.js';
 import { SpiderContext } from '../context.js';
 import { Project } from '../../index.js';
 import { ensureDir } from "fs-extra";
+import path from 'node:path';
 
 export async function downloadHandler(context: SpiderContext): Promise<void> {
-  const { graph, files, saveResource, sendRequest } = context;
+  const { graph, files, saveResource } = context;
   const resource = await saveResource();
 
-  const buffer = await sendRequest({
-    responseType: 'buffer',
-    resolveBodyOnly: true,
-    allowGetBody: true,
-    decompress: true,
-    method: 'GET',
+  const response = await fetch(resource.parsed)
+  .then(r => {
+    if (r.status !== 200) throw new Error('Could not download');
+    return r;
   });
 
-  const fileName =
-    resource.key +
-    '-' +
-    fileNameFromHeaders(new URL(buffer.url), buffer.headers);
+  if (response.body) {
+    const fileName =
+      resource.key +
+      '-' +
+      fileNameFromHeaders(new URL(resource.url), resource.headers);
 
-  const directory = [resource.parsed.hostname.replaceAll('.', '-'), resource.mime?.replaceAll('/', '-') ?? 'unknown'].join('/')
-  const proj = await Project.config();
-  await ensureDir([proj.root ?? '.', 'storage', 'downloads', directory].join('/'));
-  await files('downloads').writeStream([directory, fileName].join('/'), Readable.from(buffer.rawBody));
+    const directory = path.join(resource.parsed.hostname.replaceAll('.', '-'), resource.mime?.replaceAll('/', '-') ?? 'unknown');
+    const proj = await Project.config();
+    await ensureDir(path.join(proj.root ?? '.', 'storage', 'downloads', directory));
+    const fullPath = path.join(directory, fileName);
+    await files('downloads').writeStream(fullPath, Duplex.from(response.body));
 
-  resource.payload = { bucket: 'downloads', path: fileName };
-  await graph.push(resource);
+    resource.payload = { bucket: 'downloads', path: fullPath };
+    await graph.push(resource);
+  }
+  return Promise.resolve();
 }

--- a/src/spider/handlers/failure-handler.ts
+++ b/src/spider/handlers/failure-handler.ts
@@ -22,6 +22,7 @@ export async function failureHandler(context: SpiderContext, error: Error) {
   });
 
   await graph.push([rs, rw]);
+  return Promise.resolve();
 }
 
 export function findFailureCode(error: Error | string) {

--- a/src/spider/handlers/page-handler.ts
+++ b/src/spider/handlers/page-handler.ts
@@ -12,4 +12,5 @@ export async function pageHandler(context: SpiderContext) {
       handler: 'sitemap',
     });
   }
+  return Promise.resolve();
 }

--- a/src/spider/handlers/status-handler.ts
+++ b/src/spider/handlers/status-handler.ts
@@ -3,4 +3,5 @@ import { SpiderContext } from '../context.js';
 export async function statusHandler(context: SpiderContext): Promise<void> {
   const { saveResource } = context;
   await saveResource();
+  return Promise.resolve();
 }


### PR DESCRIPTION
Downloading files as part of the crawl is currently borked; this patch fixes it and standardizes a `storage/downloads/domain/mimetype/UUID-filename.bar` naming convention for downloaded files.