### PR TITLE
v0.10.4 changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added a `collapseSearchParams` normalizer option, so borked URL Search Param values like `page=1?page=2?page=3` can be collapsed to the last value in the list. The config value should be a glob pattern matching Search Param keys; i.e., `'name'` or `'{name,id,search}'` etc.
 - Added support for stealth crawling; setting `spider.stealth` to TRUE in the Spidergram config will use the `playwright-extras` plugin to mask the crawler's identity. This is experimental and turned off by default; some pages currently cause it to crash the spider, requiring repeated restarts of the crawler to finish a site.
 - Added a `delete` CLI command that can be used to remove crawl records and dependent relationships. It uses the same filtering syntax as the `query` CLI command, but is obviously much more dangerous. Using `query` first, then `delete`ing when you know you're sure of the results, is strongly recommended. This is particularly useful, though, when you'd like to 'forget' and re-crawl a set of pages. In the future we'll be adding support for explicitly recrawling without this dangerous step, but for now it's quite handy.
+- Bumped `@axe-core/playwright` to version 4.7.1
 
 ## v0.10.3 - 23-05-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Spidergram Changelog
 
+## v0.10.4 - 23-05-22
+
+- Fixed URL crawl/save filtering. If multiple filters are supplied, *any* match will cause the URL to be treated as a match. Explicit rejection of URLs is still possible using the full UrlFilter syntax; i.e., `crawl: { propert: 'hostname', glob: '*foo.com', reject: true }`.
+- Added a `collapseSearchParams` normalizer option, so borked URL Search Param values like `page=1?page=2?page=3` can be collapsed to the last value in the list. The config value should be a glob pattern matching Search Param keys; i.e., `'name'` or `'{name,id,search}'` etc.
+- Added support for stealth crawling; setting `spider.stealth` to TRUE in the Spidergram config will use the `playwright-extras` plugin to mask the crawler's identity. This is experimental and turned off by default; some pages currently cause it to crash the spider, requiring repeated restarts of the crawler to finish a site.
+
 ## v0.10.3 - 23-05-10
 
 - Disable pattern discovery and site name extraction when using the `ping` command to avoid altering crawl data

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fixed URL crawl/save filtering. If multiple filters are supplied, *any* match will cause the URL to be treated as a match. Explicit rejection of URLs is still possible using the full UrlFilter syntax; i.e., `crawl: { propert: 'hostname', glob: '*foo.com', reject: true }`.
 - Added a `collapseSearchParams` normalizer option, so borked URL Search Param values like `page=1?page=2?page=3` can be collapsed to the last value in the list. The config value should be a glob pattern matching Search Param keys; i.e., `'name'` or `'{name,id,search}'` etc.
 - Added support for stealth crawling; setting `spider.stealth` to TRUE in the Spidergram config will use the `playwright-extras` plugin to mask the crawler's identity. This is experimental and turned off by default; some pages currently cause it to crash the spider, requiring repeated restarts of the crawler to finish a site.
+- Added a `delete` CLI command that can be used to remove crawl records and dependent relationships. It uses the same filtering syntax as the `query` CLI command, but is obviously much more dangerous. Using `query` first, then `delete`ing when you know you're sure of the results, is strongly recommended. This is particularly useful, though, when you'd like to 'forget' and re-crawl a set of pages. In the future we'll be adding support for explicitly recrawling without this dangerous step, but for now it's quite handy.
 
 ## v0.10.3 - 23-05-10
 
@@ -84,7 +85,7 @@ This release is dedicated to Peter Porker of Earth-8311, an innocent pig raised 
   - `report.dropEmptyQueries` does what it says on the tin
   - `report.pivotSingleResults` triggers a check for queries that return only one row, and pivots them for friendlier display. Still experimental.
   - The `report.queries` list allows a new 'modified query' structure, which includes both a pointer to an already-defined base query and a set of additional filters, return values, and so on. This allows you to reuse complex base, then filter them to a specific subdomain or other criteria without copying and pasting the underlying definition.
-  - `report.modifications` is an optional list of modifications that will be made to _each query_ in the report.
+  - `report.modifications` is an optional list of modifications that will be made to *each query* in the report.
   - The `spidergram report` command now supports the `--filter` flag; any filters from the command line will be added as 'modifications' to the report when it runs, allowing you to build a universal report and run it multiple times with different filters.
 - Added a simple check for certain recursive URL chains (like `http://example.com/~/~/~/~`). `spider.urls.recursivePathThreshold` is set to 3 by default, and setting it to 1 or less turns off the recursion-check.
 - The `spider.auditAccessibility` setting now allows the full audit to be saved to a separate table, with several summary formats (by impact, by category) for the primary results saved to the Resource.
@@ -233,7 +234,7 @@ This release is dedicated to teen crime-fighter Gwen Stacy of Earth-65. She jugg
 
 ## v0.8.0 - 23-01-27
 
-This release is dedicated to Miles Morales of Earth-6160, star of _Into The Spider-Verse_.
+This release is dedicated to Miles Morales of Earth-6160, star of *Into The Spider-Verse*.
 
 - Improvements to structured **data and content parsing**; `HtmlTools.getPageData()` and `HtmlTools.getPageContent()` are now useful as general-purpose extractors across most crawl data.
 - `HtmlTools.findPattern()` now pulls **more data for each component**, including raw internal markup if desired.

--- a/package.json
+++ b/package.json
@@ -102,8 +102,10 @@
     "office-document-properties": "^1.1.0",
     "p-queue": "^7.3.4",
     "pdfjs-dist": "^3.4.120",
+    "playwright-extra": "^4.3.6",
     "prepend-http": "^4.0.0",
     "proload-plugin-json5": "github:autogram-is/proload-plugin-json5",
+    "puppeteer-extra-plugin-stealth": "^2.11.2",
     "read-pkg-up": "^9.1.0",
     "readability-scores": "^1.0.8",
     "reflect-metadata": "^0.1.13",
@@ -154,7 +156,7 @@
     "crawlee": "^3.2.0",
     "googleapis": "^108.0.1",
     "html-to-text": "^9.0.0",
-    "playwright": "^1.32.1",
+    "playwright": "^1.33.0",
     "vega": "^5.22.1",
     "vega-lite": "^5.6.0"
   }

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@sindresorhus/is": "^5.3.0",
     "@types/js-yaml": "^4.0.5",
     "@vladfrangu/async_event_emitter": "^2.1.2",
-    "aql-builder": "^0.5.6",
+    "aql-builder": "^0.6.0",
     "arrify": "^3.0.0",
     "caterpillar": "^6.8.0",
     "chalk": "^5.1.2",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   },
   "dependencies": {
     "@autogram/url-tools": "^2.5.4",
-    "@axe-core/playwright": "^4.6.0",
+    "@axe-core/playwright": "^4.7.1",
     "@oclif/plugin-help": "^5",
     "@oclif/plugin-plugins": "^2.4.1",
     "@proload/core": "^0.3.3",

--- a/src/cli/commands/delete.ts
+++ b/src/cli/commands/delete.ts
@@ -1,0 +1,43 @@
+import { SgCommand } from '../index.js';
+import { Flags, ux } from '@oclif/core';
+import { buildFilter } from '../shared/flag-query-tools.js';
+import { queryFilterFlag } from '../shared/index.js';
+
+import { Spidergram } from '../../index.js';
+import { SpiderCli } from '../shared/spider-cli.js';
+
+export default class DeleteEntities extends SgCommand {
+  static description = 'Remove entries from the crawl database';
+
+  static flags = {
+    collection: Flags.string({
+      char: 'c',
+      summary: 'The collection whose items should be deleted',
+    }),
+    filter: {
+      ...queryFilterFlag,
+      summary: 'Filter criteria for documents to delete',
+    },
+    orphans: Flags.boolean({
+      char: 'o',
+      summary: 'Delete orphaned relationships',
+    }),
+    limit: Flags.integer({
+      char: 'l',
+      summary: 'Maximum number of documents to delete',
+    }),
+    force: Flags.boolean({
+      char: 'y',
+      summary: 'Skip confirmation prompt',
+    }),
+  };
+
+  async run() {
+    const { flags } = await this.parse(DeleteEntities);
+    const cli = new SpiderCli();
+    const sg = await Spidergram.load();
+
+    
+  }
+
+}

--- a/src/cli/commands/delete.ts
+++ b/src/cli/commands/delete.ts
@@ -1,13 +1,12 @@
-import { SgCommand } from '../index.js';
-import { Flags, ux } from '@oclif/core';
+import { CLI, SgCommand } from '../index.js';
+import { Flags } from '@oclif/core';
 import { buildFilter } from '../shared/flag-query-tools.js';
 import { queryFilterFlag } from '../shared/index.js';
 
-import { Spidergram } from '../../index.js';
-import { SpiderCli } from '../shared/spider-cli.js';
+import { Query, Spidergram } from '../../index.js';
 
 export default class DeleteEntities extends SgCommand {
-  static description = 'Remove entries from the crawl database';
+  static description = 'Delete entries from the crawl database';
 
   static flags = {
     collection: Flags.string({
@@ -34,10 +33,74 @@ export default class DeleteEntities extends SgCommand {
 
   async run() {
     const { flags } = await this.parse(DeleteEntities);
-    const cli = new SpiderCli();
     const sg = await Spidergram.load();
 
-    
-  }
+    const docCollections = ['unique_urls', 'resources', 'sites', 'patterns', 'fragments'];
+    const relCollections = ['appears_on', 'links_to', 'is_child_of', 'is_variant_of', 'responds_with'];
 
+    // If a collection was passed in, start building a query.
+    // If 'orphans' was specified, start calculating the number of 
+  
+    if (flags.collection) {
+      if (!docCollections.includes(flags.collection)) {
+        this.error(`No collection named '${flags.collection}'.`);
+      }
+
+      const q = new Query(flags.collection);
+      if (flags.filter) {
+        for (const f of flags.filter ?? []) {
+          q.filterBy(buildFilter(f));
+        }
+      }
+
+      const cq = new Query(q.spec);
+      cq.return('_id')
+      const delCount = (await cq.run()).length;
+
+      if (delCount === 0) {
+        this.error('No matching documents.');
+      }
+
+      const confirmation = flags.force ? true : await CLI.confirm(`Delete ${delCount} matching ${flags.collection} documents?`);
+      if (!confirmation) {
+        this.ux.info(`Delete canceled; no documents were affected.`);
+        this.exit(0);
+      }
+
+      if (flags.orphans) {
+        const confirmation = flags.force ? true : await CLI.confirm(`Delete all relationships connected to the affected documents?`);
+        if (!confirmation) {
+          this.ux.info(`Delete canceled; no documents or relationships were affected.`);
+          this.exit(0);
+        }
+  
+        q.spec.return = undefined;
+        q.spec.remove = undefined;
+        q.return('_id');
+        const ids = await q.run<string>();
+
+        const queries: Query[] = [];
+
+        for (const rel of relCollections) {
+          queries.push(new Query(rel).filterBy('_from', ids).remove());
+          queries.push(new Query(rel).filterBy('_to', ids).remove());
+        }
+
+        // Special case handling for body HTML storage; we need to clean this up later.
+        if (q.spec.collection === 'resources' && sg.config.offloadBodyHtml === 'db') {
+          queries.push(new Query('kv_body_html').filterBy('_key', ids).remove());
+        }
+
+        for (const qs of queries) {
+          this.ux.action.status = qs.spec.collection.toString();
+          await qs.run();
+        }
+      }
+      
+      q.spec.remove = undefined;
+      q.spec.return = undefined;
+      q.remove();
+      await q.run();
+    }
+  }
 }

--- a/src/cli/commands/delete.ts
+++ b/src/cli/commands/delete.ts
@@ -74,6 +74,8 @@ export default class DeleteEntities extends SgCommand {
           this.exit(0);
         }
   
+        this.ux.action.start('Deleting');
+        
         q.spec.return = undefined;
         q.spec.remove = undefined;
         q.return('_id');
@@ -95,11 +97,14 @@ export default class DeleteEntities extends SgCommand {
           this.ux.action.status = qs.spec.collection.toString();
           await qs.run();
         }
+
+        this.ux.action.stop();
       }
       
       q.spec.remove = undefined;
       q.spec.return = undefined;
       q.remove();
+      this.ux.action.status = q.spec.collection.toString();
       await q.run();
     }
   }

--- a/src/config/global-normalizer.ts
+++ b/src/config/global-normalizer.ts
@@ -73,7 +73,8 @@ export interface NormalizerOptions {
 
   /**
    * For any search/querystring parameters whose names match the supplied pattern, collapse
-   * multiple values and use only the last one.
+   * multiple values and use only the last one. Setting the property to `true` collapses
+   * all search parameters regardless of name.
    * 
    * @example
    * ```
@@ -83,7 +84,7 @@ export interface NormalizerOptions {
    * // https://example.com/search.html?page=3
    * ```
    */
-  collapseSearchParams?: string
+  collapseSearchParams?: true | string
 
   /**
    * Alphabetize any search/querystring parameters, so links that supply params in different

--- a/src/spider/handlers/page-handler.ts
+++ b/src/spider/handlers/page-handler.ts
@@ -1,10 +1,12 @@
+import { getPageMarkup } from '../../tools/browser/get-page-markup.js';
 import { BrowserTools } from '../../tools/index.js';
 import { SpiderContext } from '../context.js';
 
 export async function pageHandler(context: SpiderContext) {
   const { saveResource, enqueueUrls, page } = context;
 
-  const body = await page.content();
+  const body = await getPageMarkup(page, context.shadowDom);
+
   const cookies = context.saveCookies
     ? await page.context().cookies()
     : undefined;

--- a/src/spider/links/save-urls.ts
+++ b/src/spider/links/save-urls.ts
@@ -8,7 +8,7 @@ import {
   UrlTools,
   HtmlTools,
   NormalizedUrl,
-  aql,
+  Query,
 } from '../../index.js';
 import _ from 'lodash';
 
@@ -100,12 +100,10 @@ export async function saveUrls(
     results.links.length > 0 &&
     options.discardExisting
   ) {
-    const deleteLinkTos = aql`
-      FOR lt IN links_to
-      FILTER lt._from == ${resource.documentId}
-      REMOVE lt IN links_to
-    `;
-    await graph.db.query(deleteLinkTos);
+    await new Query('links_to')
+      .filterBy('_from', resource.documentId)
+      .remove()
+      .run()
   }
 
   return graph

--- a/src/spider/spider-options.ts
+++ b/src/spider/spider-options.ts
@@ -23,6 +23,26 @@ export interface InternalSpiderOptions extends Dictionary {
   logLevel: LogLevel;
 
   /**
+   * Iterate over the browser document to ensure Shadow DOM elements
+   * are recognized and included in the page content.
+   * 
+   * Note: This may interfere with interactive on-page elements; in general,
+   * it should only be turned on if you know page content is NOT being
+   * recognized.
+   * 
+   * @defaultValue false
+   */
+  shadowDom?: boolean;
+
+  /**
+   * The indicator to wait for when determining whether a page has been fully loaded.
+   * 
+   * @see {@link Playwright Navigation Lifecycle | https://playwright.dev/dotnet/docs/navigations#navigation-lifecycle }
+   * @defaultValue "networkidle"
+   */
+  waitUntil?: "load"|"domcontentloaded"|"networkidle"|"commit";
+
+  /**
    * A function to process a successfully loaded page view. If none is
    * supplied, the default pageHandler will:
    *

--- a/src/spider/spider-options.ts
+++ b/src/spider/spider-options.ts
@@ -98,6 +98,14 @@ export interface InternalSpiderOptions extends Dictionary {
   urls: EnqueueUrlOptions;
 
   /**
+   * Tailor the spider's browser settings to hide the fact that it's an automated
+   * crawler. If this option is set, the {@link userAgent} property will be ignored.
+   * 
+   * Note that the stealth option is experimental and may cause issues with some sites.
+   */
+  stealth?: boolean;
+
+  /**
    * An array of MIME type strings used to recognize HTTP requests as
    * parsable HTML pages. Specific mime types or glob strings ('text/*', etc.)
    * can be used.

--- a/src/spider/spider.ts
+++ b/src/spider/spider.ts
@@ -112,12 +112,29 @@ export class Spider extends PlaywrightCrawler {
       crawler.launchContext = { userAgent: internal.userAgent };
     }
 
+    crawler.browserPoolOptions = {
+      preLaunchHooks: [
+        async (_, launchContext) => {
+          launchContext.ignoreHTTPSErrors = true
+        }
+      ],
+    };
+
     // We're bumping this up to deal with exceptionally horrible sites.
     if (options.auditAccessibility) {
       // …And adding an extra buffer when the all1 checker is turned on.
       crawler.requestHandlerTimeoutSecs = (internal.handlerTimeout ?? 60) + 30;
     } else {
       crawler.requestHandlerTimeoutSecs = internal.handlerTimeout;
+    }
+
+    if (options.waitUntil) {
+      crawler.preNavigationHooks.push(
+        (ctx, opt) => {
+          opt ??= {};
+          opt.waitUntil = options.waitUntil;
+        } 
+      );
     }
 
     super(crawler, config);
@@ -306,6 +323,8 @@ function splitOptions(options: Partial<SpiderOptions> = {}) {
     postNavigationHooks,
     userAgent,
     handlerTimeout,
+    waitUntil,
+    shadowDom,
 
     ...crawlerOptions
   } = options;

--- a/src/tools/browser/get-page-markup.ts
+++ b/src/tools/browser/get-page-markup.ts
@@ -1,0 +1,23 @@
+import { Page } from 'playwright';
+
+/**
+ * Iterates through the document, loading the innerHTML of Shadow Dom elements.
+ * 
+ * @see {@link https://docs.apify.com/academy/node-js/scraping-shadow-doms}
+ */
+export async function getPageMarkup(page: Page, shadowDom?: boolean) {
+  if (shadowDom) {
+    return page.evaluate<string>(
+      () => {
+        for (let el of document.getElementsByTagName('*')) {
+          // If element contains shadow root then replace its 
+          // content with the HTML of shadow DOM.
+          if (el.shadowRoot) el.innerHTML = el.shadowRoot.innerHTML;
+        }
+        return document.documentElement.outerHTML;
+      }
+    )
+  } else {
+    return page.content();
+  }
+}


### PR DESCRIPTION
- Fixed URL crawl/save filtering. If multiple filters are supplied, *any* match will cause the URL to be treated as a match. Explicit rejection of URLs is still possible using the full UrlFilter syntax; i.e., `crawl: { propert: 'hostname', glob: '*foo.com', reject: true }`.
- Added a `collapseSearchParams` normalizer option, so borked URL Search Param values like `page=1?page=2?page=3` can be collapsed to the last value in the list. The config value should be a glob pattern matching Search Param keys; i.e., `'name'` or `'{name,id,search}'` etc.
- Added support for stealth crawling; setting `spider.stealth` to TRUE in the Spidergram config will use the `playwright-extras` plugin to mask the crawler's identity. This is experimental and turned off by default; some pages currently cause it to crash the spider, requiring repeated restarts of the crawler to finish a site.
- Added a `delete` CLI command that can be used to remove crawl records and dependent relationships. It uses the same filtering syntax as the `query` CLI command, but is obviously much more dangerous. Using `query` first, then `delete`ing when you know you're sure of the results, is strongly recommended. This is particularly useful, though, when you'd like to 'forget' and re-crawl a set of pages. In the future we'll be adding support for explicitly recrawling without this dangerous step, but for now it's quite handy.
- Bumped `@axe-core/playwright` to version 4.7.1
